### PR TITLE
Input string should be parsed completely

### DIFF
--- a/src/main/antlr4/org/alessio29/savagebot/r2/grammar/R2.g4
+++ b/src/main/antlr4/org/alessio29/savagebot/r2/grammar/R2.g4
@@ -4,6 +4,10 @@ grammar R2;
 //    mvn generate-sources
 // or antlr4:antlr4 goal
 
+commandElement
+    :   statement (';' statement)* ';'? EOF
+    ;
+
 statement
     :   e=expression
         # RollOnceStmt

--- a/src/test/java/tests/TestR2Parser.java
+++ b/src/test/java/tests/TestR2Parser.java
@@ -343,6 +343,53 @@ public class TestR2Parser {
         );
     }
 
+    @Test
+    public void testCommandSeparation() {
+        expect(
+                "RollOnce\n" +
+                        "  expr: GenericRoll isOpenEnded=false\n" +
+                        "    diceCount: null\n" +
+                        "    facetsCount: Int 6\n" +
+                        "    suffixArg: null\n" +
+                        "RollOnce\n" +
+                        "  expr: GenericRoll isOpenEnded=false\n" +
+                        "    diceCount: null\n" +
+                        "    facetsCount: Int 6\n" +
+                        "    suffixArg: null",
+                "d6 d6"
+        );
+        expect(
+                "NonParsedString text='d6d6' parserErrorMessage='[2]: mismatched input 'd' expecting {<EOF>, ';'}'",
+                "d6d6"
+        );
+        expect(
+                "RollOnce\n" +
+                        "  expr: GenericRoll isOpenEnded=false\n" +
+                        "    diceCount: null\n" +
+                        "    facetsCount: Int 6\n" +
+                        "    suffixArg: null\n" +
+                        "RollOnce\n" +
+                        "  expr: GenericRoll isOpenEnded=false\n" +
+                        "    diceCount: null\n" +
+                        "    facetsCount: Int 6\n" +
+                        "    suffixArg: null",
+                "d6", "d6"
+        );
+        expect(
+                "RollOnce\n" +
+                        "  expr: GenericRoll isOpenEnded=false\n" +
+                        "    diceCount: null\n" +
+                        "    facetsCount: Int 6\n" +
+                        "    suffixArg: null\n" +
+                        "RollOnce\n" +
+                        "  expr: GenericRoll isOpenEnded=false\n" +
+                        "    diceCount: null\n" +
+                        "    facetsCount: Int 6\n" +
+                        "    suffixArg: null",
+                "d6;d6"
+        );
+    }
+
     private void expect(String expectedDump, String... args) {
         List<Statement> statements = new Parser().parse(args);
         StringWriter sw = new StringWriter();


### PR DESCRIPTION
(otherwise parser treats incorrect input such as 'd4abcdef' as 'd4')