### PR TITLE
Alternative target numbers for Savage Worlds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<basedir>D:/GIT_REPO/savagebot/</basedir>
 		<javalib>d:/Archive/java_lib/</javalib>
 
-        <antlr.version>4.7.2</antlr.version>
+        <antlr.version>4.8</antlr.version>
 	</properties>
 
 	<build>

--- a/src/main/antlr4/org/alessio29/savagebot/r2/grammar/R2.g4
+++ b/src/main/antlr4/org/alessio29/savagebot/r2/grammar/R2.g4
@@ -64,7 +64,7 @@ genericRollSuffix
     ;
 
 savageWorldsRoll
-    :   (t1=term)? ('s'|'S') t2=term (('w'|'W') t3=term)?
+    :   (t1=term)? ('s'|'S') t2=term (('w'|'W') t3=term)? (('t'|'T') t4=term)?
     ;
 
 fudgeRoll

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionContext.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionContext.java
@@ -10,6 +10,8 @@ class ExpressionContext {
     private final CommandContext commandContext;
     private final Map<Expression, String> explanations = new HashMap<>();
 
+    private int savageWorldsTargetNumber = 4;
+
     public ExpressionContext(Expression topExpression, CommandContext commandContext) {
         this.topExpression = topExpression;
         this.commandContext = commandContext;
@@ -29,5 +31,13 @@ class ExpressionContext {
 
     public CommandContext getCommandContext() {
         return commandContext;
+    }
+
+    public void setSavageWorldsTargetNumber(int targetNumber) {
+        savageWorldsTargetNumber = targetNumber;
+    }
+
+    public int getSavageWorldsTargetNumber() {
+        return savageWorldsTargetNumber;
     }
 }

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionEvaluator.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionEvaluator.java
@@ -288,6 +288,9 @@ public class ExpressionEvaluator implements Expression.Visitor<List<Integer>> {
 
         context.putExplanation(savageWorldsRollExpression, result.getExplained());
 
+        int targetNumber = evalInt(savageWorldsRollExpression.getTargetNumberArg(), 4);
+        context.setSavageWorldsTargetNumber(targetNumber);
+
         return result.getValues();
     }
 

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionExplainer.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionExplainer.java
@@ -41,10 +41,16 @@ class ExpressionExplainer implements Expression.Visitor<String> {
     }
 
     private String getSuccessesIfAny(int intValue) {
-        if (intValue < 4) {
+        int targetNumber = expressionContext.getSavageWorldsTargetNumber();
+        int marginOfSuccess = intValue - targetNumber;
+        if (marginOfSuccess < 0) {
             return "";
         } else {
-            return " (" + (intValue / 4) + ")";
+            StringBuilder sb = new StringBuilder().append(" (").append(marginOfSuccess / 4 + 1);
+            if (targetNumber != 4) {
+                sb.append("; TN: ").append(targetNumber);
+            }
+            return sb.append(")").toString();
         }
     }
 

--- a/src/main/java/org/alessio29/savagebot/r2/parse/ExpressionDesugarer.java
+++ b/src/main/java/org/alessio29/savagebot/r2/parse/ExpressionDesugarer.java
@@ -232,7 +232,8 @@ class ExpressionDesugarer extends Desugarer<Expression> {
                 getOriginalText(ctx),
                 visitOrNull(swrc.t1),
                 visit(swrc.t2),
-                visitOrNull(swrc.t3)
+                visitOrNull(swrc.t3),
+                visitOrNull(swrc.t4)
         );
     }
 

--- a/src/main/java/org/alessio29/savagebot/r2/tree/SavageWorldsRollExpression.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/SavageWorldsRollExpression.java
@@ -4,17 +4,20 @@ public class SavageWorldsRollExpression extends Expression {
     private final Expression diceCountArg;
     private final Expression abilityDieArg;
     private final Expression wildDieArg;
+    private final Expression targetNumberArg;
 
     public SavageWorldsRollExpression(
             String text,
             Expression diceCountArg,
             Expression abilityDieArg,
-            Expression wildDieArg
+            Expression wildDieArg,
+            Expression targetNumberArg
     ) {
         super(text);
         this.diceCountArg = diceCountArg;
         this.abilityDieArg = abilityDieArg;
         this.wildDieArg = wildDieArg;
+        this.targetNumberArg = targetNumberArg;
     }
 
     public Expression getDiceCountArg() {
@@ -27,6 +30,10 @@ public class SavageWorldsRollExpression extends Expression {
 
     public Expression getWildDieArg() {
         return wildDieArg;
+    }
+
+    public Expression getTargetNumberArg() {
+        return targetNumberArg;
     }
 
     @Override

--- a/src/test/java/org/alessio29/savagebot/parsing/TestR2Interpreter.java
+++ b/src/test/java/org/alessio29/savagebot/parsing/TestR2Interpreter.java
@@ -470,6 +470,23 @@ public class TestR2Interpreter {
     }
 
     @Test
+    public void testSavageWorldsChecksWithAlternativeTargetNumber() {
+        expect(
+                "s8t6+4: [6; w5] + 4 = **10** (2; TN: 6)",
+                "s8t6+4"
+        );
+    }
+
+    @Test
+    public void testMultipleSavageWorldChecksWithTargetNumbers() {
+        // We treat such expression as a basic expression, and don't count number of successes.
+        expect(
+                "s8t4+s8t6: [6; w5] + [2; w28] = **34**",
+                "s8t4+s8t6"
+        );
+    }
+
+    @Test
     public void testBracketsInExplanationOfSumRollMultipliedBySomething() {
         expect(
                 "3*3d6: 3 * (1 + 5 + 2) = **24**",

--- a/src/test/java/org/alessio29/savagebot/parsing/TestR2Parser.java
+++ b/src/test/java/org/alessio29/savagebot/parsing/TestR2Parser.java
@@ -26,7 +26,7 @@ public class TestR2Parser {
                 "NonParsedString text='abc' parserErrorMessage='[0]: token recognition error at: 'ab''\n" +
                         "NonParsedString text='def' parserErrorMessage='[1]: token recognition error at: 'e''\n" +
                         "NonParsedString text='qwer' parserErrorMessage='[0]: token recognition error at: 'q''\n" +
-                        "NonParsedString text='tty' parserErrorMessage='[0]: token recognition error at: 't''\n" +
+                        "NonParsedString text='tty' parserErrorMessage='[0]: mismatched input 't' expecting {'+', '-', 'd', 'D', 's', 'S', 'dF', 'df', 'DF', 'dC', 'dc', 'DC', '(', INT, FLAG, VAR}'\n" +
                         "RollOnce\n" +
                         "  expr: Int 123",
                 "abc def", "  qwer tty", "123"


### PR DESCRIPTION
Syntax example:
```
  s8t6+2
```
- roll s8+2, remembering that target number is 6,
and print out number of successes against TN 6.

Also, bump antlr version.