### PR TITLE
Alternative raise steps for Savage Worlds rolls

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,33 @@ You can make multiple rolls in one command separated by space: `!r d6 d4! d10+d1
 
 You can use comments in roll: `!r shooting at vampire s8 damage 2d6+1`
 
+Roll dice command can be anywhere in your message: `Shooting: !s10`
+
 Currently supported dice codes are:
 
 `!3d6` - roll 3 6-sided dice, show sum
 
 `!2d8!` - roll 2 'exploding' 8-sided dice, show sum. 'Exploding' means that if die come up with maximum value - it will be rolled again and summed up 
 
-`!4d6k3` - roll 4 6-sided dice keep 3 highest (DnD attributes roll-up)
+`!4d6k3` - roll 4 6-sided dice, keep 3 highest
+
+`!6x4d6k3` - repeat 6 times: roll 4 6-sided dice, keep 3 highest 
 
 `!2d10kl1` - roll 2 10-sided dice keep 1 lowest
 
-`!s8` - Savage Worlds roll with trait die d8 and wild die d6
+`!s8` - Savage Worlds roll with d8 trait die and (default) d6 wild die
 
-`!3s8` - Savage Worlds roll with three trait die d8 (Can be used for bursts)
+`!3s8` - Savage Worlds roll with three d8 trait dice (e.g., bursts)
 
 `!s8w10` - Savage Worlds roll with trait die d8 and wild die d10
 
-`!3s8w8` - Savage Worlds roll with three trait die d8 and wild die d8 (bursts with non-default wild die)
+`!3s8w8` - Savage Worlds roll with three d8 trait dice and d8 wild die (e.g., bursts with non-default wild die)
+
+`!s8t6` - Savage Worlds roll with trait die d8 and target number 6 (for counting successes and raises)
+
+`!s8tr6` - Savage Worlds roll with trait die d8, target number 6, and raise step 6
+
+`!s8t10r6` - Savage Worlds roll with trait die d8, target number 10, and raise step 6
 
 Also SavageBot supports custom TN and counting raises from it. To do so - use the following syntax: `s6t5`. Result will look like: 
 
@@ -95,33 +105,37 @@ Bot supports limits to roll:
 
 `!dC` - Carcosa roll. First d20 is rolled to determine size of dice - then this dice is rolled.
 
-**rh**    <expression_1> ... <expressionN>    creates data for histogram: rolls dice multiple times and shows resulting distribution. 
+`!rh    <expression_1> ... <expressionN>`    creates data for histogram: rolls dice multiple times and shows resulting distribution. 
 Example: `!rh 1000x2d6` - rolls 2d6 1000 times and shows results table.
   
-**rs**    [<heading_1>] <expression_1> ... [<heading_N>] <expression_N>    rolls multiple dice and print them out sorted.
+`!rs    [<heading_1>] <expression_1> ... [<heading_N>] <expression_N>`    rolls multiple dice and print them out sorted.
 This is mostly useful for rolling initiative as a single command.
-!rs Huey d20 Dewey d20 Louie d20 => 
-`Dewey 14
+```
+> !rs Huey d20 Dewey d20 Louie d20 
+Dewey 14
 Huey 10
-Louie 5`
+Louie 5
+```
 
 __**TOKENS category**__
 
-**give** character1 [token count1] [character2 [token count2]] [...]		Gives token(s) to character(s). 
+`!give character1 [token count1] [character2 [token count2]] [...]`		Gives token(s) to character(s). 
 
 Example: `!give Huey 2 Louie Dewey 3` - gives 2 tokens to Huey, 1 to Louie and 3 to Dewey. 
 
 
-**take** character [token count] [character2 [token count2]] [...]    Takes token(s) from character(s).  
+`!take character [token count] [character2 [token count2]] [...]`    Takes token(s) from character(s).  
 
 Example: `!give Huey Louie Dewey 2` - takes 1 tokens from Huey, 1 from Louie and 2 from Dewey.
 
 
-**clear** character1 [character2] [...] /all    Clears token(s) for sprecified character or for all characters in channel
+`!clear character1 [character2] [...] /all`    Clears token(s) for sprecified character or for all characters in channel
 
 __**STATES category**__
 
-**state** or **st** <character_name1> [+/-]<state1> [+/-][<state2>] [...]   Sets and removes states of character.
+`!state <character_name1> [+/-]<state1> [+/-][<state2>] [...]`
+
+`!st <character_name1> [+/-]<state1> [+/-][<state2>] [...]` Sets and removes states of character.
   
   Example: `!state Huey +stunned -vul dis Dewey dis -ent Louie clear`
   

--- a/src/main/antlr4/org/alessio29/savagebot/r2/grammar/R2.g4
+++ b/src/main/antlr4/org/alessio29/savagebot/r2/grammar/R2.g4
@@ -64,7 +64,11 @@ genericRollSuffix
     ;
 
 savageWorldsRoll
-    :   (t1=term)? ('s'|'S') t2=term (('w'|'W') t3=term)? (('t'|'T') t4=term)?
+    :   (t1=term)? ('s'|'S') t2=term (('w'|'W') t3=term)?
+        (
+         ( (('t'|'T') t4=term)? (('r'|'R') t5=term)? )
+         | ( ('tr'|'TR') t6=term )
+        )
     ;
 
 fudgeRoll

--- a/src/main/java/org/alessio29/savagebot/internal/RedisClient.java
+++ b/src/main/java/org/alessio29/savagebot/internal/RedisClient.java
@@ -1,6 +1,5 @@
 package org.alessio29.savagebot.internal;
 
-import jdk.nashorn.internal.runtime.ECMAException;
 import org.alessio29.savagebot.internal.utils.JsonConverter;
 import org.apache.log4j.Logger;
 import redis.clients.jedis.Jedis;

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionContext.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionContext.java
@@ -11,6 +11,7 @@ class ExpressionContext {
     private final Map<Expression, String> explanations = new HashMap<>();
 
     private int savageWorldsTargetNumber = 4;
+    private int savageWorldsRaiseStep = 4;
 
     public ExpressionContext(Expression topExpression, CommandContext commandContext) {
         this.topExpression = topExpression;
@@ -39,5 +40,13 @@ class ExpressionContext {
 
     public int getSavageWorldsTargetNumber() {
         return savageWorldsTargetNumber;
+    }
+
+    public void setSavageWorldsRaiseStep(int raiseStep) {
+        savageWorldsRaiseStep = raiseStep;
+    }
+
+    public int getSavageWorldsRaiseStep() {
+        return savageWorldsRaiseStep;
     }
 }

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionEvaluator.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionEvaluator.java
@@ -288,8 +288,18 @@ public class ExpressionEvaluator implements Expression.Visitor<List<Integer>> {
 
         context.putExplanation(savageWorldsRollExpression, result.getExplained());
 
-        int targetNumber = evalInt(savageWorldsRollExpression.getTargetNumberArg(), 4);
-        context.setSavageWorldsTargetNumber(targetNumber);
+        Expression targetNumberAndRaiseStepArg = savageWorldsRollExpression.getTargetNumberAndRaiseStepArg();
+        if (targetNumberAndRaiseStepArg == null) {
+            int targetNumber = evalInt(savageWorldsRollExpression.getTargetNumberArg(), 4);
+            context.setSavageWorldsTargetNumber(targetNumber);
+
+            int raiseStep = evalInt(savageWorldsRollExpression.getRaiseStepArg(), 4);
+            context.setSavageWorldsRaiseStep(raiseStep);
+        } else {
+            int targetNumberAndRaiseStep = evalInt(targetNumberAndRaiseStepArg, 4);
+            context.setSavageWorldsTargetNumber(targetNumberAndRaiseStep);
+            context.setSavageWorldsRaiseStep(targetNumberAndRaiseStep);
+        }
 
         return result.getValues();
     }

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionExplainer.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionExplainer.java
@@ -42,13 +42,20 @@ class ExpressionExplainer implements Expression.Visitor<String> {
 
     private String getSuccessesIfAny(int intValue) {
         int targetNumber = expressionContext.getSavageWorldsTargetNumber();
+        int raiseStep = expressionContext.getSavageWorldsRaiseStep();
+        if (raiseStep <= 0) {
+            throw new EvaluationErrorException("Raise step should be above 0: " + raiseStep);
+        }
         int marginOfSuccess = intValue - targetNumber;
         if (marginOfSuccess < 0) {
             return "";
         } else {
-            StringBuilder sb = new StringBuilder().append(" (").append(marginOfSuccess / 4 + 1);
+            StringBuilder sb = new StringBuilder().append(" (").append(marginOfSuccess / raiseStep + 1);
             if (targetNumber != 4) {
                 sb.append("; TN: ").append(targetNumber);
+            }
+            if (raiseStep != 4) {
+                sb.append("; raise step: ").append(raiseStep);
             }
             return sb.append(")").toString();
         }

--- a/src/main/java/org/alessio29/savagebot/r2/parse/ExpressionDesugarer.java
+++ b/src/main/java/org/alessio29/savagebot/r2/parse/ExpressionDesugarer.java
@@ -228,13 +228,27 @@ class ExpressionDesugarer extends Desugarer<Expression> {
     public Expression visitSavageWorldsRollExpr(R2Parser.SavageWorldsRollExprContext ctx) {
         R2Parser.SavageWorldsRollContext swrc = ctx.savageWorldsRoll();
 
-        return new SavageWorldsRollExpression(
-                getOriginalText(ctx),
-                visitOrNull(swrc.t1),
-                visit(swrc.t2),
-                visitOrNull(swrc.t3),
-                visitOrNull(swrc.t4)
-        );
+        if (swrc.t6 == null) {
+            return new SavageWorldsRollExpression(
+                    getOriginalText(ctx),
+                    visitOrNull(swrc.t1),
+                    visit(swrc.t2),
+                    visitOrNull(swrc.t3),
+                    visitOrNull(swrc.t4),
+                    visitOrNull(swrc.t5),
+                    null
+            );
+        } else {
+            return new SavageWorldsRollExpression(
+                    getOriginalText(ctx),
+                    visitOrNull(swrc.t1),
+                    visit(swrc.t2),
+                    visitOrNull(swrc.t3),
+                    null,
+                    null,
+                    visitOrNull(swrc.t6)
+            );
+        }
     }
 
     private Expression visitOrNull(ParseTree parseTree) {

--- a/src/main/java/org/alessio29/savagebot/r2/tree/SavageWorldsRollExpression.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/SavageWorldsRollExpression.java
@@ -5,19 +5,25 @@ public class SavageWorldsRollExpression extends Expression {
     private final Expression abilityDieArg;
     private final Expression wildDieArg;
     private final Expression targetNumberArg;
+    private final Expression raiseStepArg;
+    private final Expression targetNumberAndRaiseStepArg;
 
     public SavageWorldsRollExpression(
             String text,
             Expression diceCountArg,
             Expression abilityDieArg,
             Expression wildDieArg,
-            Expression targetNumberArg
+            Expression targetNumberArg,
+            Expression raiseStepArg,
+            Expression targetNumberAndRaiseStepArg
     ) {
         super(text);
         this.diceCountArg = diceCountArg;
         this.abilityDieArg = abilityDieArg;
         this.wildDieArg = wildDieArg;
         this.targetNumberArg = targetNumberArg;
+        this.raiseStepArg = raiseStepArg;
+        this.targetNumberAndRaiseStepArg = targetNumberAndRaiseStepArg;
     }
 
     public Expression getDiceCountArg() {
@@ -34,6 +40,14 @@ public class SavageWorldsRollExpression extends Expression {
 
     public Expression getTargetNumberArg() {
         return targetNumberArg;
+    }
+
+    public Expression getRaiseStepArg() {
+        return raiseStepArg;
+    }
+
+    public Expression getTargetNumberAndRaiseStepArg() {
+        return targetNumberAndRaiseStepArg;
     }
 
     @Override

--- a/src/test/java/org/alessio29/savagebot/parsing/TestR2Interpreter.java
+++ b/src/test/java/org/alessio29/savagebot/parsing/TestR2Interpreter.java
@@ -475,6 +475,34 @@ public class TestR2Interpreter {
                 "s8t6+4: [6; w5] + 4 = **10** (2; TN: 6)",
                 "s8t6+4"
         );
+        expect(
+                "10xs12t5r5: \n" +
+                        "1: s12t5r5: [1; w5] = **5** (1; TN: 5; raise step: 5)\n" +
+                        "2: s12t5r5: [2; w28] = **28** (5; TN: 5; raise step: 5)\n" +
+                        "3: s12t5r5: [4; w3] = **4**\n" +
+                        "4: s12t5r5: [6; w17] = **17** (3; TN: 5; raise step: 5)\n" +
+                        "5: s12t5r5: [21; w5] = **21** (4; TN: 5; raise step: 5)\n" +
+                        "6: s12t5r5: [4; w9] = **9** (1; TN: 5; raise step: 5)\n" +
+                        "7: s12t5r5: [8; w1] = **8** (1; TN: 5; raise step: 5)\n" +
+                        "8: s12t5r5: [9; w9] = **9** (1; TN: 5; raise step: 5)\n" +
+                        "9: s12t5r5: [5; w4] = **5** (1; TN: 5; raise step: 5)\n" +
+                        "10: s12t5r5: [11; w1] = **11** (2; TN: 5; raise step: 5)",
+                "10xs12t5r5"
+        );
+        expect(
+                "10xs12tr5: \n" +
+                        "1: s12tr5: [1; w5] = **5** (1; TN: 5; raise step: 5)\n" +
+                        "2: s12tr5: [2; w28] = **28** (5; TN: 5; raise step: 5)\n" +
+                        "3: s12tr5: [4; w3] = **4**\n" +
+                        "4: s12tr5: [6; w17] = **17** (3; TN: 5; raise step: 5)\n" +
+                        "5: s12tr5: [21; w5] = **21** (4; TN: 5; raise step: 5)\n" +
+                        "6: s12tr5: [4; w9] = **9** (1; TN: 5; raise step: 5)\n" +
+                        "7: s12tr5: [8; w1] = **8** (1; TN: 5; raise step: 5)\n" +
+                        "8: s12tr5: [9; w9] = **9** (1; TN: 5; raise step: 5)\n" +
+                        "9: s12tr5: [5; w4] = **5** (1; TN: 5; raise step: 5)\n" +
+                        "10: s12tr5: [11; w1] = **11** (2; TN: 5; raise step: 5)",
+                "10xs12tr5"
+        );
     }
 
     @Test


### PR DESCRIPTION
Syntax:
`!s8tr6` - set both TN and raise step to 6
`!s8t10r6` - TN 10, raise step 6
`!s8r6` - TN 4 (default), raise step 6