### PR TITLE
Documentation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,10 @@ Once you gave a Benny to a character, it remains in the `list`, even if they rea
 !remove Assassin
 ```
 
-**Tips:** You can remove multiple characters at one: `!remove LordDenak GoblinWarlord EliteSentinel`
+**Tips:** You can remove multiple characters at one: 
+```
+!remove LordDenak GoblinWarlord EliteSentinel
+```
 
 ---
 # Characters

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Oops, Snake Eyes!
 ```
 Huey's Persuasion is !s8
 ```
+And modifiers are also supported. Let's take a Wild Card untrained Trait roll: `!s4-2`.
 
 ## Fighting vs Parry
 For rolls where the Target Number is not the standard 4, you can add a `t` parameter after the `s` savage roll.

--- a/README.md
+++ b/README.md
@@ -407,6 +407,27 @@ At the end of each round of Mass Battles, `give` or `take` tokens from each side
 !give TheHeroes 1
 ```
 
+## Social Conflicts
+Same as with Mass Battles and Dramatic Tasks, deal bennies to virtual characters to track the Social Conflict progress. Here let's call it MsInfluence.
+
+### Start a Social Conflict
+In case you already had a Social Conflict running, remove MsInfluence from the character list.
+```
+!remove MsInfluence
+!list
+```
+
+### Gain Influence
+Simply `give` Bennies to MsInfluence each time your arguments have gained you some influence.
+```
+!give MsInfluence 1
+```
+
+At the end of the three rounds, check how many influence MsInfluence has gained:
+```
+!list
+```
+
 ## Deadland Bennies
 Deadlands uses a pool of colored Bennies. Each color has its own uses. Characters draw Bennies at random from the pool.
 This will use complete different command than regular Bennies. We assume Bennies are drawn (`benny`) from a `hat` and placed in the character's `pocket` until they `use` them. Do NOT use `clear`, `give`, or `take` for Deadlands bennies.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supports various dice-rolling, Savage Worlds initiative cards, bennies, tokens, 
 In case you like this bot so much - you can support development via Patreon: https://www.patreon.com/savagebot
 
 ## Installation
-Click on the following link and authorize bot on your server: https://discordapp.com/oauth2/authorize?&client_id=448952545784758303&scope=bot&permissions=0
+Click on this link and [authorize bot on your server](https://discordapp.com/oauth2/authorize?&client_id=448952545784758303&scope=bot&permissions=0)
 
 To know whether the bot is alive:
 ```
@@ -198,7 +198,7 @@ You can take away from multiple players, multiple Bennies in a single line.
 ```
 
 ## Who has what?
-The `list`command lets you check how many Bennies each character has. (it also shows states, see [Managing character states](#states) below).
+The `list` command lets you check how many Bennies each character has. (it also shows states, see [States](#states) below).
 ```
 !list
 ```
@@ -235,7 +235,7 @@ Once you gave a Benny to a character, it remains in the `list`, even if they rea
 # Characters
 
 ## Add characters
-Users often ask *how do I add players to my game?*. Well, you don't. Players (and characters) are automatically added if you deal them an initiative card, a Benny (or a state see [Managing character states](#states) below).
+Users often ask *how do I add players to my game?*. Well, you don't. Players (and characters) are automatically added if you deal them an initiative card, a Benny (or a state see [States](#states) below).
 
 ## Who is playing?
 Use `list` to have the list of players/characters currently in the game. It shows their name, Bennies (tokens), and states.
@@ -304,7 +304,7 @@ Want to see if a character is Shaken or Distracted?
 
 ## Advanced Rolls
 
-### Emote and Narrative
+### Emotes and Narration
 You roll multiple separate rolls on the same line/command and put narrative text around as you like. Note that it returns to next line after each roll:
 ```
 The assassin shoots at Huey !s8 Damage: !2d6!+1 Bonus damage (if raise): !d6!
@@ -325,7 +325,16 @@ The number of success and raises is calculated accordingly:
 > Huey Fighting vs Bandit: s10t6: [9; w3] = 9 (1; TN: 6)
 ```
 
-**Not yet:** You can't compare damage to toughness and read the number of wounds. `!2d6!t8` isn't available yet.
+**Not yet:** You can't compare damage to toughness and read the number of wounds (yet).
+
+### Multiple Modifiers
+You don't want to add up penalties and bonuses by yourself? Let's go lazy, Savage Bot does it for you.
+Melee attack with Called Shot to Head, Dim Light, Trademark Weapon, and Wild attack?
+```
+!s10-4-2+1+2
+> s10-4-2+1+2: [7; w4] - 4 - 2 + 1 + 2 = 4 (1)
+```
+That was close!
 
 ### Custom Wild Die
 If a character has an Edge such as Master, they get to roll a Wild Die higher than d6. You can add `w` to the Savage roll to tell which Wild Die to use.
@@ -334,10 +343,10 @@ Here is Master d12+2, using a d10 for Wild Die.
 !s12w10+2
 ```
 
-**Tips:** You can combine with specific target number, but if you add modifiers, you must also add parenthesis.
+**Tips:** You can combine with specific target number.
 This rolls d12+2, with a d10 for Wild Die, against Parry 8.
 ```
-!(s12w10t8)+2
+!s12w10t8+2
 ```
 
 ### Multi-dice

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ As a wild card, the syntax is simpler, prefix your savage die with the number of
 !2s6
 ```
 
-**Tips:** This also works with Custom Wild Die and Modifiers, e.g. `!3s12w10+2`. But not yet with Target Numbers (Parry): `!3s6t2` (TN 2 is ignored here).
+**Tips:** This also works with Custom Wild Die and Modifiers, e.g. `!3s12w10+2`. But not (yet) with Target Numbers (Parry): `!3s6t2` (TN 2 is ignored here).
 
 ### Group Rolls
 Group Rolls are used in Savage Worlds to simulate an average result for a group of extra (e.g. when they all sneak on the party, all attempt to notice something, or evaluate how well they survive their journey through the desert). It is resolved using a single Trait roll plus a standard d6 Wild Die. So simply use the `s` Savage Die!
@@ -369,32 +369,37 @@ Group Rolls are used in Savage Worlds to simulate an average result for a group 
 ### Custom Rolls
 For a specific setting or house-rule you need something even more specific? Here are a few tricks that can be useful.
 
-TODO: variant raise step.
+**Raise step other than 4**
+If you need to count number of success and raises in step of 3 or 6 (instead of the standard 4):
+```
+!s8r6
+> s8r6: [10; w1] = 10 (2; raise step: 6)
+```
 
-`!s8` - Savage Worlds roll with d8 trait die and (default) d6 wild die
+With specific target number:
+```
+!s12t8r6
+> s12t8r6: [16; w1] = 16 (2; TN: 8; raise step: 6)
+```
 
-`!3s8` - Savage Worlds roll with three d8 trait dice (e.g., bursts)
+When target number and raise steps are the same:
+```
+!s12tr6
+> s12tr6: [9; w3] = 9 (1; TN: 6; raise step: 6)
+```
 
-`!s8w10` - Savage Worlds roll with trait die d8 and wild die d10
+And with custom Wild Die too:
+```
+!s12w8t5r3
+> s12w8t5r3: [7; w2] = 7 (1; TN: 5; raise step: 3)
+```
 
-`!3s8w8` - Savage Worlds roll with three d8 trait dice and d8 wild die (e.g., bursts with non-default wild die)
-
-`!s8t6` - Savage Worlds roll with trait die d8 and target number 6 (for counting successes and raises)
-
-`!s8tr6` - Savage Worlds roll with trait die d8, target number 6, and raise step 6
-
-`!s8t10r6` - Savage Worlds roll with trait die d8, target number 10, and raise step 6
-
-Also SavageBot supports custom TN and counting raises from it. To do so - use the following syntax: `s6t5`. Result will look like: 
-
-  s6t5: [11; w8] = 11 (2; TN: 5) 
-
-This means: roll result is 11, 2 - is success with one raise, TN is self-explanatory.
-
-This may be combined with othe roll options, like custom wild die: `!s6w8t7`.
-
-Bot supports limits to roll: 
-`!r (3d8!+d6!)[6:24+6]` - this roll will give value at least 6 and no more than 30 (24+6). This used in our house-rule for damage rolls for Savage Worlds.
+**Limit roll results**
+You will roll and sum up multiple dice, but you want the result to be not too extreme? You can put a lower and higher limit on your rolls. Here, we want the result to be between 6 and 30 (24+6).
+```
+!r (3d8!+d6!)[6:24+6]
+```
+This used in our house-rule for damage rolls for Savage Worlds.
 
 ## Dramatic Tasks
 When running a Dramatic Tasks, players must collect a given amount of tokens in a set number of rounds.

--- a/README.md
+++ b/README.md
@@ -576,14 +576,34 @@ Currently supported dice codes are:
 Example: `!rh 1000x2d6` - rolls 2d6 1000 times and shows results table.
 
 ## Cards
+Here are a few commands to manipulate a standard deck of 54 cards.
+This feature is pretty old and quite limited. It might get a rework later on.
 
-__**CARDS category**__
+### Deal Cards
+`deal` or `dl` deals cards in secret to you. Each player must use this command themselves. You can't deal to another person. The cards dealt are sent by direct message to you.
 
-**deal** or **dl**    [<card_count>] Secretly deals several (1 by default) cards to user's private channel
+This deals a hand of 5 cards:
+```
+!dl 5
+```
 
-**show** or **sh**    Shows your cards, previously dealt to you by 'deal' command to current channel
+### What's my Hand?
+`show` or `sh` displays your current hand of cards.
+```
+!show
+> 3 :spades: Q :hearts: 2 :hearts: 10 :spades: 4 :hearts:
+```
 
-**put**         Deals card and "puts it on table" (shows in current channel). 
+### Draw to the Table
+`put` does draw a card from the deck and put it on the table for everyone to see.
 
-**shuffle**        Shuffles current deck, resets secret cards dealt to all users in this channel
+This draws three cards, and drop them on the table.
+```
+!put 3
+```
 
+### Shuffle
+Grabs every cards back and shuffle into a new fresh deck.
+```
+!shuffle
+```

--- a/README.md
+++ b/README.md
@@ -136,11 +136,10 @@ As a wild card, the syntax is simpler, prefix your savage die with the number of
 !2s6
 ```
 
-**Tips:** This also works with Custom Wild Die, e.g. `!3s12w10+2`. But not yet with Target Numbers (Parry).
+**Tips:** This also works with Custom Wild Die and Modifiers, e.g. `!3s12w10+2`. But not yet with Target Numbers (Parry): `!3s6t2` (TN 2 is ignored here).
 
 ## Group Rolls
 Group Rolls are used in Savage Worlds to simulate an average result for a group of extra (e.g. when they all sneak on the party, all attempt to notice something, or evaluate how well they survive their journey through the desert). It is resolved using a single Trait roll plus a standard d6 Wild Die. So simply use the `s` Savage Die!
-
 ```
 !s6
 ```
@@ -233,6 +232,106 @@ Oh, you can also do that when you start a new round, by adding the character nam
 !rd + -Bandits
 ```
 
+---
+# Bennies
+## Grant a Benny
+To give a Benny to a player (or character), use the `!give` command.
+```
+!give Huey
+```
+
+To grant multiple Bennies at once, add the number of Bennies after the character name.
+```
+!give Huey 3
+```
+
+You can give Bennies to multiple persons at once, for example when a Joker is dealt.
+This gives 2 to Huey, one to Louie, and 3 to Dewey.
+```
+!give Huey 2 Louie Dewey 3
+```
+
+## Spend a Benny
+When a player wants to spend a Benny, the Game Master `take` it from them (or they take it away from themselves).
+```
+!take Huey
+```
+
+You can take away from multiple players, multiple Bennies in a single line.
+```
+!take Huey Louie 2 Dewey 2
+```
+
+## Who has what?
+The `list`command lets you check how many Bennies each character has. (it also shows states, see [Managing character states](#states) below).
+```
+!list
+```
+
+Here is what the result looks like:
+```
+> NAME                TOKENS    STATES                             
+> Huey                2                                            
+> Dewey               4                                            
+> Louie               2              
+```
+
+## New session
+When you start a new session and want to reset all Bennies to default 3 (or more with Edges), first use the `clear` command to remove all remaining Bennies, and then, `give` each character what they deserve.
+
+Here, our group with Huey, Louie, and Dewey, and Louie has the Luck Edge:
+```
+!clear
+!give Huey 3 Louie 4 Dewey 3
+```
+
+### Removing characters
+Once you gave a Benny to a character, it remains in the `list`, even if they reach 0 Benny. It's ok when it's a player, at some point they will regain some Benny, but for Wild Card NPCs, you might want to `remove` them from the list.
+```
+!remove Assassin
+```
+
+**Tips:** You can remove multiple characters at one: `!remove LordDenak GoblinWarlord EliteSentinel`
+
+## Deadland Bennies
+Deadlands uses a pool of colored Bennies. Each color has its own uses. Characters draw Bennies at random from the pool.
+This will use complete different command than regular Bennies. We assume Bennies are drawn (`benny`) from a `hat` and placed in the character's `pocket` until they `use` them. Do NOT use `clear`, `give`, or `take` for Deadlands bennies.
+
+**Trivia:** Savage Bot started out aimed for Deadlands players. That's why the `benny` command is for Deadlands Bennies and not for standard Savage Worlds bennies.
+
+### New Deadlands session
+Fill your hat with 20 white Bennies, 10 red Bennies, 5 blue Bennies (and no Golden ones):
+```
+!hat fill
+```
+
+### Grant Deadlands Bennies
+Use `benny` to draw a random Benny from the hand and deal it to a single character.
+```
+!benny Huey
+```
+
+**Note:** as of now, there is no way to draw multiple Deadlands Bennies at once, and no way to deal to multiple players at once.
+
+### Spend Deadlands Bennies
+The `use` command lets you spend a Benny of a given color from a character.
+```
+!use white Huey
+```
+
+### What's in your pocket?
+To check a character's pocket for Deadlands Bennies, use `pocket`.
+```
+!pocket Huey
+```
+
+**Note:** at the moment, there is no way to check for all characters' pockets at once.
+
+### What's left in the hat?
+Using `hat` command without the `fill` argument, you simply check how many Bennies of each color are left in the hat.
+```
+!hat
+```
 
 ------
 OLD (upcoming)
@@ -255,22 +354,6 @@ __**CARDS category**__
 **shuffle**        Shuffles current deck, resets secret cards dealt to all users in this channel
 
 
-
-__**TOKENS category**__
-
-`!give character1 [token count1] [character2 [token count2]] [...]`		Gives token(s) to character(s). 
-
-Example: `!give Huey 2 Louie Dewey 3` - gives 2 tokens to Huey, 1 to Louie and 3 to Dewey. 
-
-
-`!take character [token count] [character2 [token count2]] [...]`    Takes token(s) from character(s).  
-
-Example: `!give Huey Louie Dewey 2` - takes 1 tokens from Huey, 1 from Louie and 2 from Dewey.
-
-
-`!clear character1 [character2] [...] /all`    Clears token(s) for sprecified character or for all characters in channel
-
-
 __**STATES category**__
 
 `!state <character_name1> [+/-]<state1> [+/-][<state2>] [...]`
@@ -280,17 +363,6 @@ __**STATES category**__
   Example: `!state Huey +stunned -vul dis Dewey dis -ent Louie clear`
   
   States are Savage Worlds states: Shaken, Stunned, Entangled, Bound, Distracted and Vulnerable. You can write them in any case even like sTuNnEd. You can use abbreviations: sha, stn, ent, bnd, dis, vul.
-
-
-__**BENNIES category**__
-
-**pocket**		<characterName>	Shows character's bennies
-
-**use**			Uses one of character's benny
-
-**benny**		<character>	Get benny from hat and adds it to characker's pocket
-
-**hat**		[fill]	Puts all required bennies into the hat
 
 
 __**DICE category**__

--- a/README.md
+++ b/README.md
@@ -92,11 +92,7 @@ Oops, Snake Eyes!
 > s12: [1; w1] = 1
 ```
 
-**Tips:** You can put descriptive text before the roll (it will return to next line after each roll).
-```
-Huey's Persuasion is !s8
-```
-And modifiers are also supported. Let's take a Wild Card untrained Trait roll: `!s4-2`.
+**Tips:** Modifiers are also supported. Let's take a Wild Card untrained Trait roll: `!s4-2`.
 
 ## Damage rolls
 Pretty simple, back to standard `d` syntax. Damage dice ace.
@@ -109,17 +105,6 @@ Here is a knife (Str+d4) wielding bandit with d6 strength:
 Here is a bow (2d6) wielding assassin:
 ```
 !2d6!
-```
-
-**Tips:** You roll multiple separate rolls on the same line, and put texts around as you like.
-```
-The assassin shoots at Huey !s8 Damage: !2d6!+1 Bonus damage (if raise): !d6!
-```
-Will display:
-```
-> The assassin shoots at Huey s8: [1; w3] = 3
-> Damage: 2d6!+1: 5 + 1 + 1 = 7
-> Bonus damage (if raise): d6!: 1 = 1
 ```
 
 ---
@@ -318,6 +303,15 @@ Want to see if a character is Shaken or Distracted?
 # Advanced Savage Worlds
 
 ## Advanced Rolls
+
+### Emote and Narrative
+You roll multiple separate rolls on the same line/command and put narrative text around as you like. Note that it returns to next line after each roll:
+```
+The assassin shoots at Huey !s8 Damage: !2d6!+1 Bonus damage (if raise): !d6!
+> The assassin shoots at Huey s8: [1; w3] = 3
+> Damage: 2d6!+1: 5 + 1 + 1 = 7
+> Bonus damage (if raise): d6!: 1 = 1
+```
 
 ### Variable Target Number (Fighting vs Parry)
 For rolls where the Target Number is not the standard 4, you can add a `t` parameter after the `s` savage roll.

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Here, our group with Huey, Louie, and Dewey, and Louie has the Luck Edge:
 !give Huey 3 Louie 4 Dewey 3
 ```
 
-### Removing characters
+## Removing characters
 Once you gave a Benny to a character, it remains in the `list`, even if they reach 0 Benny. It's ok when it's a player, at some point they will regain some Benny, but for Wild Card NPCs, you might want to `remove` them from the list.
 ```
 !remove Assassin
@@ -333,14 +333,28 @@ Using `hat` command without the `fill` argument, you simply check how many Benni
 !hat
 ```
 
-------
-OLD (upcoming)
+---
+# Characters
 
-__**CHARACTERS category**__
+## Add characters
+Users often ask *how do I add players to my game?*. Well, you don't. Players (and characters) are automatically added if you deal them an initiative card, a Benny (or a state see [Managing character states](#states) below).
 
-**list**        Lists characters with tokens and states
+## Who is playing?
+Use `list` to have the list of players/characters currently in the game. It shows their name, Bennies (tokens), and states.
+```
+!list
+```
 
-**remove**      <charName1> [<charName2> ...] Removes character(s) totally. This command could be used to erase defeated extras.
+## Remove characters
+Since the `list` holds players and characters, and since some characters might just have to leave (defeated, passing by npc, ...), you can `remove` characters:
+```
+!remove BigBadEvilBoss BigBagLieutnant
+```
+
+## Character Sheets
+At the moment, Savage Bot does not manage Character Sheets. You can't roll `!persuasion` or `!fighting`.
+
+Players or GMs usually keep the character sheets on paper in front of them, or use online sites such as [Savaged.us](http://savaged.us), or Virtual TableTop softwares with Character Sheets abilities. Whatever works for you. The simpler the better. Fast! Fun! Furious!
 
 
 __**CARDS category**__

--- a/README.md
+++ b/README.md
@@ -117,6 +117,30 @@ This rolls d12+2, with a d10 for Wild Die, against Parry 8.
 !(s12w10t8)+2
 ```
 
+## Multi-dice
+Weapons with a Rate of Fire, Frenzy, Work the Room, there are situations where you need to roll multiple Trait dice for a single action (and a single Wild Die if you are a Wild Card). 
+
+As an extra, prefix with the number of dice to roll and a x (for *times*)
+```
+!2xd6!
+```
+
+As a wild card, the syntax is simpler, prefix your savage die with the number of dice to roll:
+```
+!2s6
+```
+
+**Tips:** This also works with Custom Wild Die, e.g. `!3s12w10+2`. But not yet with Target Numbers (Parry).
+
+## Group Rolls
+Group Rolls are used in Savage Worlds to simulate an average result for a group of extra (e.g. when they all sneak on the party, all attempt to notice something, or evaluate how well they survive their journey through the desert). It is resolved using a single Trait roll plus a standard d6 Wild Die. So simply use the `s` Savage Die!
+
+```
+!s6
+```
+
+**Tips:** Groups rolls are not used in combat. You'll have to roll each extra action one by one. However, you can roll multiple dice at once like this: `!5d6!` (5 extra rolling a d6 Trait).
+
 ## Damage rolls
 Pretty simple, back to standard `d` syntax. Damage dice ace.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ For example, you need to know in which direction a grenade deviates?
 ```
 !r d12
 ```
+or for short:
+```
+!d12
+```
+
 **Tips:** 
 * In fact, you can just roll any die `!d20`, `!d100`, even very weird ones `!d73` if you feel like it!
 * You can also directly include modifiers (after or before the roll), for example, here is a human running roll `!6+d6`.

--- a/README.md
+++ b/README.md
@@ -268,16 +268,42 @@ Players or GMs usually keep the character sheets on paper in front of them, or u
 
 ---
 # States
+In Savage Worlds, states are effects that affects a character for some time, like being Shaken, Distracted, or Vulnerable.
 
-__**STATES category**__
+Savage Bot allows you to track the following states: Shaken, Stunned, Entangled, Bound, Distracted and Vulnerable.
 
-`!state <character_name1> [+/-]<state1> [+/-][<state2>] [...]`
+## Apply State to Character
+When a character is Shaken, or Entangled, or whatnot, use the `state` command to track it.
+```
+!state Huey +Vulnerable
+```
 
-`!st <character_name1> [+/-]<state1> [+/-][<state2>] [...]` Sets and removes states of character.
-  
-  Example: `!state Huey +stunned -vul dis Dewey dis -ent Louie clear`
-  
-  States are Savage Worlds states: Shaken, Stunned, Entangled, Bound, Distracted and Vulnerable. You can write them in any case even like sTuNnEd. You can use abbreviations: sha, stn, ent, bnd, dis, vul.
+**Tips:** You can use the shortened version of each state: Shaken → sha, Stunned → stn, Entangled → ent, Bound → bnd, Distracted → dis and Vulnerable → vul. You can also apply a state to multiple characters at once.
+```
+!state Huey +stn Dewey +dis Louie +bnd
+```
+
+## Remove State from Character
+Use `state` again, with a minus sign.
+```
+!state Huey -vul
+```
+
+To remove all states from a character, add `clear` after their name. This removes all states from Huey:
+```
+!state Huey clear
+```
+
+**Tips:** You can apply and remove states to a single character at once. You omit the `+` sign, it is still considered a "add/apply". This adds Stunned and Distracted to Huey while also removing Distracted, add Distracted to Dewey but also adds Entangled, and clears everything from Louie. Yeah, we know some nasty GMs!
+```
+!state Huey +stunned -vul dis Dewey dis -ent Louie clear
+```
+
+## How Are You Doing?
+Want to see if a character is Shaken or Distracted?
+```
+!list
+```
 
 ---
 # Advanced Savage Worlds

--- a/README.md
+++ b/README.md
@@ -515,50 +515,85 @@ Using `hat` command without the `fill` argument, you simply check how many Benni
 ---
 # Other Systems
 
+## West End Games D6 System
+One d6 is Wild: it explodes on 6 and subtracts highest number on 1.
+
+```
+!3w
+> 3w: w11 + 6 + 4 = 21
+```
+
 ## Worlds of Darkness
-`!Nw[+1/+2]` - West End Games D6 System roll. Rolls N d6's one of which is 'wild': it explodes on 6 and subtracts highest number on 1.
+In World of Darkness or Lady Blackbird, you roll dices and count the number of success, that is how many did hit a given target.
 
-`!6d6s4` - WoD, Lady Blackbird roll - rolls 6 d6 and returns how many dice rolled 4 or more
+Roll 6d6, successes on 4+:
+```
+!6d6s4
+> 6d6s4: [successes(3): 6, 6, 4; rest: 2, 1, 1] = 3
+```
 
-`!12d10s7` - roll 12 d10s, each 7+ result is a success, shows count of successes
+Failures removes from number of successes:
+Roll 12d10, success on 7+, failure on 1.
+```
+!12d10f1s7
+> 12d10f1s7: [successes(3): 10, 9, 7; failures(1): 1; rest: 6, 5, 5, 5, 5, 4, 3, 3] = 2
+```
 
-`!12d10f1s7` - roll 12 d10s, each 7+ result is a success, each 1- result is a failure, shows (successes-failures)
-
-`!12d10s7f1` -  same as above (you can provide success or failure condition in any order)
-
-`!28d6!f1s10` - roll 28 open-ended d6s, each 10+ is a success, each 1- is a failure, show (successes-failures)
-
-`!6x4d6k3` - roll 4 dice keeping 3 highest 6 times
+Same with exploding (open-ended, acing) dice.
+Roll 28d6, success on 10+, failture on 1-.
+```
+!28d6!s10f1
+> 28d6!s10f1: [successes(7): 15, 14, 11, 11, 10, 10, 10; failures(5): 1, 1, 1, 1, 1; rest: 9, 9, 7, 5, 5, 4, 4, 4, 4, 3, 3, 2, 2, 2, 2, 2] = 2
+```
 
 ## Coriolis
-
-`!d66` - rolls two d6 and returns values from 11 to 66 to support random choice from 6x6 table (for example in Coriolis)
+Randomly pick in a 6x6 table, roll two d6, for cols and rows (displayed as 11, 25, 66...).
+```
+!d66
+```
 
 ## Fate/Fudge
-`!4dF` - rolls four Fudge/FATE dice
+Rolls four Fudge/FATE dice.
+Roll 4 Fate dice:
+```
+!4dF
+```
 
 ## D&D
-### Roll with Advantage
-`!d20adv+2` - advantage roll in DnD5. You can roll any dice with advantage: `!3d6adv`
-### Roll with Disadvantage
-`!d20dis+2` - disadvantage roll in DnD5e. You can roll any dice with disadvantage: `!3d8dis`
-### Initiative
-`!rs    [<heading_1>] <expression_1> ... [<heading_N>] <expression_N>`    rolls multiple dice and print them out sorted.
-This is mostly useful for rolling initiative as a single command.
+Roll with Advantage (roll 2, keep highest).
+Roll a d20 with advantage and +2 modifier:
 ```
-> !rs Huey d20 Dewey d20 Louie d20 
-Dewey 14
-Huey 10
-Louie 5
+!d20adv+2
+```
+
+Roll with Disadvantage (roll 2, keep lowest).
+```
+!d20dis+2
+```
+
+To roll initiative, give character names and their initiative dice, this will sort them from highest to smallest.
+```
+!rs Huey d20 Dewey d20-2 Louie d20+4
+> Louie: d20+4: 18 + 4 = 22
+> Huey: d20: 15
+> Dewey: d20-2: 7 - 2 = 5
 ```
 
 ## Carcosa
-`!dC` - Carcosa roll. First d20 is rolled to determine size of dice - then this dice is rolled.
+First d20 is rolled to determine size of dice - then roll that dice.
+```
+!dC
+```
 
 ---
 # Other tricks
 
 ## Some Other Kind of Rolls
+
+`!6x4d6k3` - roll 4 dice keeping 3 highest 6 times
+You can roll any dice with advantage: `!3d6adv`
+You can roll any dice with disadvantage: `!3d8dis`
+
 Currently supported dice codes are:
 
 `!3d6` - roll 3 6-sided dice, show sum

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To get help from a discord channel, just type `help` command:
 ```
 
 ---
-# Dice Rolls
+# Savage Worlds Dice Rolls
 Let's first see the simpliest rolls for Savage Worlds Extra and Wild Cards. But, in the [Avanced](#advanced) section below, we will see more complex rolls as well as rolls for other systems, including D20 initiative.
 
 ## Simple rolls
@@ -98,54 +98,6 @@ Huey's Persuasion is !s8
 ```
 And modifiers are also supported. Let's take a Wild Card untrained Trait roll: `!s4-2`.
 
-## Fighting vs Parry
-For rolls where the Target Number is not the standard 4, you can add a `t` parameter after the `s` savage roll.
-For example, Huery attacks in melee a Parry 6 bandit:
-```
-Huey Fighting vs Bandit: !s10t6
-```
-
-The number of success and raises is calculated accordingly:
-```
-> Huey Fighting vs Bandit: s10t6: [9; w3] = 9 (1; TN: 6)
-```
-
-## Custom Wild Die
-If a character has an Edge such as Master, they get to roll a Wild Die higher than d6. You can add `w` to the Savage roll to tell which Wild Die to use.
-Here is Master d12+2, using a d10 for Wild Die.
-```
-!s12w10+2
-```
-
-**Tips:** You can combine with specific target number, but if you add modifiers, you must also add parenthesis.
-This rolls d12+2, with a d10 for Wild Die, against Parry 8.
-```
-!(s12w10t8)+2
-```
-
-## Multi-dice
-Weapons with a Rate of Fire, Frenzy, Work the Room, there are situations where you need to roll multiple Trait dice for a single action (and a single Wild Die if you are a Wild Card). 
-
-As an extra, prefix with the number of dice to roll and a x (for *times*)
-```
-!2xd6!
-```
-
-As a wild card, the syntax is simpler, prefix your savage die with the number of dice to roll:
-```
-!2s6
-```
-
-**Tips:** This also works with Custom Wild Die and Modifiers, e.g. `!3s12w10+2`. But not yet with Target Numbers (Parry): `!3s6t2` (TN 2 is ignored here).
-
-## Group Rolls
-Group Rolls are used in Savage Worlds to simulate an average result for a group of extra (e.g. when they all sneak on the party, all attempt to notice something, or evaluate how well they survive their journey through the desert). It is resolved using a single Trait roll plus a standard d6 Wild Die. So simply use the `s` Savage Die!
-```
-!s6
-```
-
-**Tips:** Groups rolls are not used in combat. You'll have to roll each extra action one by one. However, you can roll multiple dice at once like this: `!5d6!` (5 extra rolling a d6 Trait).
-
 ## Damage rolls
 Pretty simple, back to standard `d` syntax. Damage dice ace.
 
@@ -169,8 +121,6 @@ Will display:
 > Damage: 2d6!+1: 5 + 1 + 1 = 7
 > Bonus damage (if raise): d6!: 1 = 1
 ```
-
-**Not yet:** You can't compare damage to toughness and read the number of wounds. `!2d6!t8` isn't available yet.
 
 ---
 # Savage Worlds Initiative
@@ -293,6 +243,127 @@ Once you gave a Benny to a character, it remains in the `list`, even if they rea
 
 **Tips:** You can remove multiple characters at one: `!remove LordDenak GoblinWarlord EliteSentinel`
 
+---
+# Characters
+
+## Add characters
+Users often ask *how do I add players to my game?*. Well, you don't. Players (and characters) are automatically added if you deal them an initiative card, a Benny (or a state see [Managing character states](#states) below).
+
+## Who is playing?
+Use `list` to have the list of players/characters currently in the game. It shows their name, Bennies (tokens), and states.
+```
+!list
+```
+
+## Remove characters
+Since the `list` holds players and characters, and since some characters might just have to leave (defeated, passing by npc, ...), you can `remove` characters:
+```
+!remove BigBadEvilBoss BigBagLieutnant
+```
+
+## Character Sheets
+At the moment, Savage Bot does not manage Character Sheets. You can't roll `!persuasion` or `!fighting`.
+
+Players or GMs usually keep the character sheets on paper in front of them, or use online sites such as [Savaged.us](http://savaged.us), or Virtual TableTop softwares with Character Sheets abilities. Whatever works for you. The simpler the better. Fast! Fun! Furious!
+
+---
+# States
+
+__**STATES category**__
+
+`!state <character_name1> [+/-]<state1> [+/-][<state2>] [...]`
+
+`!st <character_name1> [+/-]<state1> [+/-][<state2>] [...]` Sets and removes states of character.
+  
+  Example: `!state Huey +stunned -vul dis Dewey dis -ent Louie clear`
+  
+  States are Savage Worlds states: Shaken, Stunned, Entangled, Bound, Distracted and Vulnerable. You can write them in any case even like sTuNnEd. You can use abbreviations: sha, stn, ent, bnd, dis, vul.
+
+---
+# Advanced Savage Worlds
+
+## Advanced Rolls
+
+### Variable Target Number (Fighting vs Parry)
+For rolls where the Target Number is not the standard 4, you can add a `t` parameter after the `s` savage roll.
+For example, Huery attacks in melee a Parry 6 bandit:
+```
+Huey Fighting vs Bandit: !s10t6
+```
+
+The number of success and raises is calculated accordingly:
+```
+> Huey Fighting vs Bandit: s10t6: [9; w3] = 9 (1; TN: 6)
+```
+
+**Not yet:** You can't compare damage to toughness and read the number of wounds. `!2d6!t8` isn't available yet.
+
+### Custom Wild Die
+If a character has an Edge such as Master, they get to roll a Wild Die higher than d6. You can add `w` to the Savage roll to tell which Wild Die to use.
+Here is Master d12+2, using a d10 for Wild Die.
+```
+!s12w10+2
+```
+
+**Tips:** You can combine with specific target number, but if you add modifiers, you must also add parenthesis.
+This rolls d12+2, with a d10 for Wild Die, against Parry 8.
+```
+!(s12w10t8)+2
+```
+
+### Multi-dice
+Weapons with a Rate of Fire, Frenzy, Work the Room, there are situations where you need to roll multiple Trait dice for a single action (and a single Wild Die if you are a Wild Card). 
+
+As an extra, prefix with the number of dice to roll and a x (for *times*)
+```
+!2xd6!
+```
+
+As a wild card, the syntax is simpler, prefix your savage die with the number of dice to roll:
+```
+!2s6
+```
+
+**Tips:** This also works with Custom Wild Die and Modifiers, e.g. `!3s12w10+2`. But not yet with Target Numbers (Parry): `!3s6t2` (TN 2 is ignored here).
+
+### Group Rolls
+Group Rolls are used in Savage Worlds to simulate an average result for a group of extra (e.g. when they all sneak on the party, all attempt to notice something, or evaluate how well they survive their journey through the desert). It is resolved using a single Trait roll plus a standard d6 Wild Die. So simply use the `s` Savage Die!
+```
+!s6
+```
+
+**Tips:** Groups rolls are not used in combat. You'll have to roll each extra action one by one. However, you can roll multiple dice at once like this: `!5d6!` (5 extra rolling a d6 Trait).
+
+### Custom Rolls
+For a specific setting or house-rule you need something even more specific? Here are a few tricks that can be useful.
+
+TODO: variant raise step.
+
+`!s8` - Savage Worlds roll with d8 trait die and (default) d6 wild die
+
+`!3s8` - Savage Worlds roll with three d8 trait dice (e.g., bursts)
+
+`!s8w10` - Savage Worlds roll with trait die d8 and wild die d10
+
+`!3s8w8` - Savage Worlds roll with three d8 trait dice and d8 wild die (e.g., bursts with non-default wild die)
+
+`!s8t6` - Savage Worlds roll with trait die d8 and target number 6 (for counting successes and raises)
+
+`!s8tr6` - Savage Worlds roll with trait die d8, target number 6, and raise step 6
+
+`!s8t10r6` - Savage Worlds roll with trait die d8, target number 10, and raise step 6
+
+Also SavageBot supports custom TN and counting raises from it. To do so - use the following syntax: `s6t5`. Result will look like: 
+
+  s6t5: [11; w8] = 11 (2; TN: 5) 
+
+This means: roll result is 11, 2 - is success with one raise, TN is self-explanatory.
+
+This may be combined with othe roll options, like custom wild die: `!s6w8t7`.
+
+Bot supports limits to roll: 
+`!r (3d8!+d6!)[6:24+6]` - this roll will give value at least 6 and no more than 30 (24+6). This used in our house-rule for damage rolls for Savage Worlds.
+
 ## Deadland Bennies
 Deadlands uses a pool of colored Bennies. Each color has its own uses. Characters draw Bennies at random from the pool.
 This will use complete different command than regular Bennies. We assume Bennies are drawn (`benny`) from a `hat` and placed in the character's `pocket` until they `use` them. Do NOT use `clear`, `give`, or `take` for Deadlands bennies.
@@ -334,88 +405,9 @@ Using `hat` command without the `fill` argument, you simply check how many Benni
 ```
 
 ---
-# Characters
+# Other Systems
 
-## Add characters
-Users often ask *how do I add players to my game?*. Well, you don't. Players (and characters) are automatically added if you deal them an initiative card, a Benny (or a state see [Managing character states](#states) below).
-
-## Who is playing?
-Use `list` to have the list of players/characters currently in the game. It shows their name, Bennies (tokens), and states.
-```
-!list
-```
-
-## Remove characters
-Since the `list` holds players and characters, and since some characters might just have to leave (defeated, passing by npc, ...), you can `remove` characters:
-```
-!remove BigBadEvilBoss BigBagLieutnant
-```
-
-## Character Sheets
-At the moment, Savage Bot does not manage Character Sheets. You can't roll `!persuasion` or `!fighting`.
-
-Players or GMs usually keep the character sheets on paper in front of them, or use online sites such as [Savaged.us](http://savaged.us), or Virtual TableTop softwares with Character Sheets abilities. Whatever works for you. The simpler the better. Fast! Fun! Furious!
-
-
-__**CARDS category**__
-
-**deal** or **dl**    [<card_count>] Secretly deals several (1 by default) cards to user's private channel
-
-**show** or **sh**    Shows your cards, previously dealt to you by 'deal' command to current channel
-
-**put**         Deals card and "puts it on table" (shows in current channel). 
-
-**shuffle**        Shuffles current deck, resets secret cards dealt to all users in this channel
-
-
-__**STATES category**__
-
-`!state <character_name1> [+/-]<state1> [+/-][<state2>] [...]`
-
-`!st <character_name1> [+/-]<state1> [+/-][<state2>] [...]` Sets and removes states of character.
-  
-  Example: `!state Huey +stunned -vul dis Dewey dis -ent Louie clear`
-  
-  States are Savage Worlds states: Shaken, Stunned, Entangled, Bound, Distracted and Vulnerable. You can write them in any case even like sTuNnEd. You can use abbreviations: sha, stn, ent, bnd, dis, vul.
-
-
-__**DICE category**__
-
-
-Currently supported dice codes are:
-
-`!3d6` - roll 3 6-sided dice, show sum
-
-`!2d8!` - roll 2 'exploding' 8-sided dice, show sum. 'Exploding' means that if die come up with maximum value - it will be rolled again and summed up 
-
-`!4d6k3` - roll 4 6-sided dice, keep 3 highest
-
-`!6x4d6k3` - repeat 6 times: roll 4 6-sided dice, keep 3 highest 
-
-`!2d10kl1` - roll 2 10-sided dice keep 1 lowest
-
-`!s8` - Savage Worlds roll with d8 trait die and (default) d6 wild die
-
-`!3s8` - Savage Worlds roll with three d8 trait dice (e.g., bursts)
-
-`!s8w10` - Savage Worlds roll with trait die d8 and wild die d10
-
-`!3s8w8` - Savage Worlds roll with three d8 trait dice and d8 wild die (e.g., bursts with non-default wild die)
-
-`!s8t6` - Savage Worlds roll with trait die d8 and target number 6 (for counting successes and raises)
-
-`!s8tr6` - Savage Worlds roll with trait die d8, target number 6, and raise step 6
-
-`!s8t10r6` - Savage Worlds roll with trait die d8, target number 10, and raise step 6
-
-Also SavageBot supports custom TN and counting raises from it. To do so - use the following syntax: `s6t5`. Result will look like: 
-
-  s6t5: [11; w8] = 11 (2; TN: 5) 
-
-This means: roll result is 11, 2 - is success with one raise, TN is self-explanatory.
-
-This may be combined with othe roll options, like custom wild die: `!s6w8t7`.
-
+## Worlds of Darkness
 `!Nw[+1/+2]` - West End Games D6 System roll. Rolls N d6's one of which is 'wild': it explodes on 6 and subtracts highest number on 1.
 
 `!6d6s4` - WoD, Lady Blackbird roll - rolls 6 d6 and returns how many dice rolled 4 or more
@@ -430,23 +422,19 @@ This may be combined with othe roll options, like custom wild die: `!s6w8t7`.
 
 `!6x4d6k3` - roll 4 dice keeping 3 highest 6 times
 
+## Coriolis
+
 `!d66` - rolls two d6 and returns values from 11 to 66 to support random choice from 6x6 table (for example in Coriolis)
 
+## Fate/Fudge
 `!4dF` - rolls four Fudge/FATE dice
 
+## D&D
+### Roll with Advantage
 `!d20adv+2` - advantage roll in DnD5. You can roll any dice with advantage: `!3d6adv`
-
+### Roll with Disadvantage
 `!d20dis+2` - disadvantage roll in DnD5e. You can roll any dice with disadvantage: `!3d8dis`
-
-Bot supports limits to roll: 
-
-`!r (3d8!+d6!)[6:24+6]` - this roll will give value at least 6 and no more than 30 (24+6). This used in our house-rule for damage rolls for Savage Worlds.
-
-`!dC` - Carcosa roll. First d20 is rolled to determine size of dice - then this dice is rolled.
-
-`!rh    <expression_1> ... <expressionN>`    creates data for histogram: rolls dice multiple times and shows resulting distribution. 
-Example: `!rh 1000x2d6` - rolls 2d6 1000 times and shows results table.
-  
+### Initiative
 `!rs    [<heading_1>] <expression_1> ... [<heading_N>] <expression_N>`    rolls multiple dice and print them out sorted.
 This is mostly useful for rolling initiative as a single command.
 ```
@@ -455,3 +443,39 @@ Dewey 14
 Huey 10
 Louie 5
 ```
+
+## Carcosa
+`!dC` - Carcosa roll. First d20 is rolled to determine size of dice - then this dice is rolled.
+
+---
+# Other tricks
+
+## Some Other Kind of Rolls
+Currently supported dice codes are:
+
+`!3d6` - roll 3 6-sided dice, show sum
+
+`!2d8!` - roll 2 'exploding' 8-sided dice, show sum. 'Exploding' means that if die come up with maximum value - it will be rolled again and summed up 
+
+`!4d6k3` - roll 4 6-sided dice, keep 3 highest
+
+`!6x4d6k3` - repeat 6 times: roll 4 6-sided dice, keep 3 highest 
+
+`!2d10kl1` - roll 2 10-sided dice keep 1 lowest
+
+## Roll Statistics
+`!rh    <expression_1> ... <expressionN>`    creates data for histogram: rolls dice multiple times and shows resulting distribution. 
+Example: `!rh 1000x2d6` - rolls 2d6 1000 times and shows results table.
+
+## Cards
+
+__**CARDS category**__
+
+**deal** or **dl**    [<card_count>] Secretly deals several (1 by default) cards to user's private channel
+
+**show** or **sh**    Shows your cards, previously dealt to you by 'deal' command to current channel
+
+**put**         Deals card and "puts it on table" (shows in current channel). 
+
+**shuffle**        Shuffles current deck, resets secret cards dealt to all users in this channel
+

--- a/README.md
+++ b/README.md
@@ -591,27 +591,72 @@ First d20 is rolled to determine size of dice - then roll that dice.
 ---
 # Other tricks
 
-## Some Other Kind of Rolls
+## Keep Highest roll
+Roll 4 d6 and keep the three best results:
+```
+!4d6k3
+```
 
-`!6x4d6k3` - roll 4 dice keeping 3 highest 6 times
-You can roll any dice with advantage: `!3d6adv`
-You can roll any dice with disadvantage: `!3d8dis`
+You can pretend to "roll with advantage" any dice. Yeah, this works with any die, not just d20. It will roll one more dice than asked and exclude the lowest from the total. 
+```
+!3d6adv
+> 3d6adv: 4 + 6 + 6 + 6 = 18
+```
 
-Currently supported dice codes are:
+## Keep Lowest
+Roll five d10 and keep the lowest two.
+```
+!5d10kl2
+> 5d10kl2: 5 + 7 + 8 + 9 + 9 = 12
+```
 
-`!3d6` - roll 3 6-sided dice, show sum
+You can also "roll with disadvantage" any dice. It will roll one more dice and exclude the highest result.
+```
+!3d8dis
+> 3d8dis: 3 + 4 + 6 + 8 = 13
+```
 
-`!2d8!` - roll 2 'exploding' 8-sided dice, show sum. 'Exploding' means that if die come up with maximum value - it will be rolled again and summed up 
+## Run multiple times the same roll
+You can repeat any roll any number of times.
+Here, roll 4d6 and keep the 3 highest, repeat 6 times.
+```
+!6x4d6k3
+> 6x4d6k3: 
+> 1: 4d6k3: 1 + 3 + 3 + 6 = 12
+> 2: 4d6k3: 2 + 2 + 5 + 6 = 13
+> 3: 4d6k3: 1 + 2 + 3 + 5 = 10
+> 4: 4d6k3: 1 + 2 + 3 + 4 = 9
+> 5: 4d6k3: 2 + 4 + 4 + 5 = 13
+> 6: 4d6k3: 1 + 2 + 3 + 4 = 9
+```
 
-`!4d6k3` - roll 4 6-sided dice, keep 3 highest
-
-`!6x4d6k3` - repeat 6 times: roll 4 6-sided dice, keep 3 highest 
-
-`!2d10kl1` - roll 2 10-sided dice keep 1 lowest
+This works with pretty much any roll.
+```
+!20x4dF
+!10xs8t7
+```
 
 ## Roll Statistics
-`!rh    <expression_1> ... <expressionN>`    creates data for histogram: rolls dice multiple times and shows resulting distribution. 
-Example: `!rh 1000x2d6` - rolls 2d6 1000 times and shows results table.
+Want to check out the probabilities of a given roll?
+Run it high number of times and have each possible result display how many times it went out.
+Here we will run 1000 times 2d6 and `rh` will tell us how many ended up with a 2, a 7, a 12...
+```
+!rh 1000x2d6
+> 2d6:
+> 2: 2d6: 22;
+> 3: 2d6: 61;
+> 4: 2d6: 69;
+> 5: 2d6: 119;
+> 6: 2d6: 142;
+> 7: 2d6: 168;
+> 8: 2d6: 115;
+> 9: 2d6: 121;
+> 10: 2d6: 97;
+> 11: 2d6: 53;
+> 12: 2d6: 33;
+```
+
+**Tips:** Since the number of rolls we called is a factor of 100, it's easy to get percentages of. (22 → 2.2%, 119 → 11.9%)
 
 ## Cards
 Here are a few commands to manipulate a standard deck of 54 cards.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,12 @@ To remove all states from a character, add `clear` after their name. This remove
 Want to see if a character is Shaken or Distracted?
 ```
 !list
+> NAME                TOKENS    STATES                             
+> Huey                1         STUNNED                            
+> Assassin            2         DISTRACTED                         
+> Dewey               1         SHAKEN                             
+> Louie               3                                            
+> Bandits             0                                    
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -364,11 +364,56 @@ This may be combined with othe roll options, like custom wild die: `!s6w8t7`.
 Bot supports limits to roll: 
 `!r (3d8!+d6!)[6:24+6]` - this roll will give value at least 6 and no more than 30 (24+6). This used in our house-rule for damage rolls for Savage Worlds.
 
+## Dramatic Tasks
+When running a Dramatic Tasks, players must collect a given amount of tokens in a set number of rounds.
+To track those tokens, we will use the Benny commands (`give`, `take`, and `list`) and a virtual character, we will call... Miss Task!
+
+### Start a Dramatic Task
+Well, in case you had a previous task running, to start out fresh, start by removing MsTask from characters.
+```
+!remove MsTask
+!list
+```
+
+**Notes:** We don't want to use `clear`, it would remove all Bennies from all players. This makes players unhappy. Not good.
+
+### Gain Task Tokens
+When players gain Task Token, deal them to MsTask.
+```
+!give MsTask 2
+```
+
+Same if they Snake Eye, and lose a Task Token:
+```
+!take MsTask 1
+```
+
+## Mass Battles
+Same as with Dramatic Tasks, use the bennies commands to deal and take from two virtual characters. Let's call them TheHeroes and TheVillains (we give them names which starts the same, so that they end up next to eachother in the characters list).
+
+### Set up a Mass Battle
+Decide which side has the maximum number of tokens (10), and how many tokens the other side gets. Then deal those amounts of tokens to our mass battle avatars. In case you had a previous Mass Battle running, don't forget to remove the avatars before giving them new tokens.
+
+```
+!remove TheHeroes TheVillains
+!give TheHeroes 7 TheVillains 10
+```
+
+### Morale and Casualties
+At the end of each round of Mass Battles, `give` or `take` tokens from each sides.
+
+```
+!take TheVillains 2
+!give TheHeroes 1
+```
+
 ## Deadland Bennies
 Deadlands uses a pool of colored Bennies. Each color has its own uses. Characters draw Bennies at random from the pool.
 This will use complete different command than regular Bennies. We assume Bennies are drawn (`benny`) from a `hat` and placed in the character's `pocket` until they `use` them. Do NOT use `clear`, `give`, or `take` for Deadlands bennies.
 
 **Trivia:** Savage Bot started out aimed for Deadlands players. That's why the `benny` command is for Deadlands Bennies and not for standard Savage Worlds bennies.
+
+Those Deadlands Bennies commands might get a rework to put them more in line with standard Benny features.
 
 ### New Deadlands session
 Fill your hat with 20 white Bennies, 10 red Bennies, 5 blue Bennies (and no Golden ones):
@@ -397,6 +442,11 @@ To check a character's pocket for Deadlands Bennies, use `pocket`.
 ```
 
 **Note:** at the moment, there is no way to check for all characters' pockets at once.
+
+### Reward a Golden Benny
+While the hat seems able to have golden bennies, there is no feature right now to add Golden Bennies to the pot, or give a Golden Benny to a player.
+
+However, if you don't use the standard Bennies commands, you could use them to stand for Golden Bennies.
 
 ### What's left in the hat?
 Using `hat` command without the `fill` argument, you simply check how many Bennies of each color are left in the hat.


### PR DESCRIPTION
Restructure readme.md to make it easier for Savage Worlds players and GM to use.
Focus on basic SW operations (rolls for extra, wc, and damage, bennies, initiative), pushes more advanced topics to an advanced section (custom wild die, frenzy, dramatic tasks, deadland bennies...), and last syntax for other systems and custom rolls.