### PR TITLE
EPT-like HP roll

### DIFF
--- a/src/main/java/org/alessio29/savagebot/apiActions/diceRolls/RollEmpireOfPetalThroneHPAction.java
+++ b/src/main/java/org/alessio29/savagebot/apiActions/diceRolls/RollEmpireOfPetalThroneHPAction.java
@@ -1,0 +1,95 @@
+package org.alessio29.savagebot.apiActions.diceRolls;
+
+import org.alessio29.savagebot.apiActions.IBotAction;
+import org.alessio29.savagebot.internal.IMessageReceived;
+import org.alessio29.savagebot.internal.builders.ReplyBuilder;
+import org.alessio29.savagebot.internal.commands.CommandExecutionResult;
+import org.alessio29.savagebot.r2.eval.CommandContext;
+import org.alessio29.savagebot.r2.eval.ExpressionEvaluator;
+import org.alessio29.savagebot.r2.eval.IntListResult;
+import org.alessio29.savagebot.r2.eval.IntResult;
+import org.alessio29.savagebot.r2.parse.Parser;
+import org.alessio29.savagebot.r2.tree.Expression;
+import org.alessio29.savagebot.r2.tree.RollOnceStatement;
+import org.alessio29.savagebot.r2.tree.Statement;
+
+import java.util.List;
+import java.util.StringJoiner;
+
+public class RollEmpireOfPetalThroneHPAction implements IBotAction {
+    @Override
+    public CommandExecutionResult doAction(IMessageReceived message, String[] args) {
+        if (args.length < 1) {
+            return new CommandExecutionResult("Expected arguments: <level> <hit_die_expression>", args.length + 1);
+        }
+
+        try {
+            CommandContext cc = new CommandContext();
+            return new CommandExecutionResult(run(args, cc), args.length + 1);
+        } catch (Throwable e) {
+            return new CommandExecutionResult(e.getMessage(), args.length + 1);
+        }
+    }
+
+    public String run(String[] args, CommandContext cc) {
+        List<Statement> parsedArgs = new Parser().parse(args);
+        if (parsedArgs.size() != 2) {
+            throw new RuntimeException("Expected 2 arguments: <level> <hit_die_expression>");
+        }
+
+        Statement levelStmt = parsedArgs.get(0);
+        if (!(levelStmt instanceof RollOnceStatement)) {
+            throw new RuntimeException("<level> argument should be an expression");
+        }
+        Statement hitDiceStmt = parsedArgs.get(1);
+        if (!(hitDiceStmt instanceof RollOnceStatement)) {
+            throw new RuntimeException("<hit_die_expression> should be an expression");
+        }
+
+        Expression levelExpr = ((RollOnceStatement) levelStmt).getExpression();
+        Expression hitDieExpr = ((RollOnceStatement) hitDiceStmt).getExpression();
+
+        StringBuilder result = new StringBuilder();
+
+        int currentHP = 0;
+        int level = eval(levelExpr, cc).getValue();
+
+        for (int i = 0; i < level; ++i) {
+            int limit = currentHP + 1;
+
+            int currentLevel = i + 1;
+            result.append("At level ").append(currentLevel).append(": ");
+            int total = 0;
+            StringJoiner sumJoiner = new StringJoiner(" + ");
+            for (int k = 0; k < currentLevel; ++k) {
+                IntResult hitDie = eval(hitDieExpr, cc);
+                int hitDieValue = Math.max(hitDie.getValue(), 1);
+                sumJoiner.add(Integer.toString(hitDieValue));
+                total += hitDieValue;
+            }
+            result.append(sumJoiner.toString()).append(" = ");
+            if (total < limit) {
+                result.append(total).append(", too low, ")
+                        .append(ReplyBuilder.bold(limit))
+                        .append(" taken");
+                currentHP = limit;
+            } else {
+                result.append(ReplyBuilder.bold(total));
+                currentHP = total;
+            }
+            result.append("\n");
+        }
+
+        result.append("HP: ").append(ReplyBuilder.bold(currentHP));
+
+        return result.toString();
+    }
+
+    private IntResult eval(Expression expression, CommandContext cc) {
+        IntListResult result = ExpressionEvaluator.evalUnsafe(expression, cc);
+        if (result.getValues().size() != 1) {
+            throw new RuntimeException("Single result expression expected: `" + expression.getText() + "`");
+        }
+        return new IntResult(result.getValues().get(0), result.getExplained());
+    }
+}

--- a/src/main/java/org/alessio29/savagebot/commands/DiceCommands.java
+++ b/src/main/java/org/alessio29/savagebot/commands/DiceCommands.java
@@ -1,9 +1,6 @@
 package org.alessio29.savagebot.commands;
 
-import org.alessio29.savagebot.apiActions.diceRolls.ParseAndRollAction;
-import org.alessio29.savagebot.apiActions.diceRolls.RollDiceAction;
-import org.alessio29.savagebot.apiActions.diceRolls.RollHistogramAction;
-import org.alessio29.savagebot.apiActions.diceRolls.RollSortedAction;
+import org.alessio29.savagebot.apiActions.diceRolls.*;
 import org.alessio29.savagebot.internal.IMessageReceived;
 import org.alessio29.savagebot.internal.commands.CommandExecutionResult;
 
@@ -57,5 +54,16 @@ public class DiceCommands {
     )
     public static CommandExecutionResult rollHistogram(IMessageReceived message, String[] args) {
         return new RollHistogramAction().doAction(message, args);
+    }
+
+    @CommandCallback(
+            name = "ept",
+            description = "rolls HP by Empire of Petal Throne rules.\n" +
+                    "Example: `!ept 4 d6+1`",
+            aliases = {},
+            arguments = { "<level> <hit_die_expression>"}
+    )
+    public static CommandExecutionResult rollEmpireOfPetalThroneHP(IMessageReceived message, String[] args) {
+        return new RollEmpireOfPetalThroneHPAction().doAction(message, args);
     }
 }

--- a/src/main/java/org/alessio29/savagebot/internal/builders/ReplyBuilder.java
+++ b/src/main/java/org/alessio29/savagebot/internal/builders/ReplyBuilder.java
@@ -56,6 +56,10 @@ public class ReplyBuilder {
         return "**" + message + "**";
     }
 
+    public static String bold(int value) {
+        return bold(Integer.toString(value));
+    }
+
     public static String italic(String message) {
         return "*" + message + "*";
     }

--- a/src/test/java/org/alessio29/savagebot/commands/TestCommandsRegistry.java
+++ b/src/test/java/org/alessio29/savagebot/commands/TestCommandsRegistry.java
@@ -5,7 +5,6 @@ import org.alessio29.savagebot.internal.commands.CommandRegistry;
 import org.alessio29.savagebot.internal.commands.Commands;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -33,7 +32,7 @@ public class TestCommandsRegistry {
                         "BENNIES:benny, BENNIES:hat, BENNIES:pocket, BENNIES:use, " +
                         "CARDS:deal, CARDS:put, CARDS:show, CARDS:shuffle, " +
                         "CHARACTERS:list, CHARACTERS:remove, " +
-                        "DICE:r, DICE:rh, DICE:rs, " +
+                        "DICE:ept, DICE:r, DICE:rh, DICE:rs, " +
                         "INFO:help, INFO:invite, " +
                         "INITIATIVE:card, INITIATIVE:di, INITIATIVE:drop, INITIATIVE:fight, INITIATIVE:init, INITIATIVE:round, " +
                         "STATES:state, "+
@@ -43,19 +42,21 @@ public class TestCommandsRegistry {
         );
     }
 
-    @Ignore
     @Test
     public void testHelpText() {
         Assert.assertEquals(
                 "__**CARDS category**__\n" +
-                        "!card <character_name>; aliases: !cd\n" +
-//                        "!deal [<card_count>]; aliases: !dl\n" +
-                        "!draw [<card_count>] [<user>]; aliases: !dw\n" +
-                        "!open [<card_count>]; aliases: !op\n" +
+                        "!deal [<card_count>] [<user>]; aliases: !dl\n" +
+                        "!put [<card_count>]\n" +
                         "!show; aliases: !sh\n" +
                         "!shuffle\n" +
                         "\n" +
+                        "__**CHARACTERS category**__\n" +
+                        "!list\n" +
+                        "!remove; aliases: !rm\n" +
+                        "\n" +
                         "__**DICE category**__\n" +
+                        "!ept <level> <hit_die_expression>\n" +
                         "!r <expression1> ... <expressionN> \n" +
                         "!rh <expression_1> ... <expressionN>\n" +
                         "!rs [<heading_1>] <expression_1> ... [<heading_N>] <expression_N>\n" +
@@ -67,8 +68,9 @@ public class TestCommandsRegistry {
                         "!use <benny_color> <character_name>\n" +
                         "\n" +
                         "__**INITIATIVE category**__\n" +
+                        "!card <character_name>; aliases: !cd\n" +
                         "!di <character_name1> [<modifiers_1>] ... <character_nameN> [<modifiers_N>]\n" +
-                        "!drop <character_name>\n"+
+                        "!drop <character_name>\n" +
                         "!fight; aliases: !f\n" +
                         "!init\n" +
                         "!round [+] [-<char_name>]; aliases: !rd\n" +
@@ -86,7 +88,9 @@ public class TestCommandsRegistry {
                         "!clear <character_name>/all\n" +
                         "!give <character_name> [<amount of tokens>]\n" +
                         "!take <character_name> [<amount of tokens>]\n" +
-                        "!tokens\n" +
+                        "\n" +
+                        "__**STATES category**__\n" +
+                        "!state <character_name> [clear] [+/-]<state1> [<state2>] [...]; aliases: !st\n" +
                         "\n" +
                         "For more details, use `!help <command>` or see https://github.com/alessio29/savagebot/blob/master/README.md",
                 HelpAction.getBriefHelpForAllCommands()

--- a/src/test/java/org/alessio29/savagebot/parsing/TestEPT.java
+++ b/src/test/java/org/alessio29/savagebot/parsing/TestEPT.java
@@ -1,0 +1,40 @@
+package org.alessio29.savagebot.parsing;
+
+import org.alessio29.savagebot.TestUtils;
+import org.alessio29.savagebot.apiActions.diceRolls.RollEmpireOfPetalThroneHPAction;
+import org.alessio29.savagebot.r2.eval.CommandContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+
+public class TestEPT {
+    @Test
+    public void testEmpireOfPetalThroneHP() {
+        expect(
+                "At level 1: 1 = **1**\n" +
+                        "At level 2: 2 + 1 = **3**\n" +
+                        "At level 3: 1 + 1 + 1 = 3, too low, **4** taken\n" +
+                        "At level 4: 1 + 1 + 1 + 2 = **5**\n" +
+                        "At level 5: 1 + 1 + 1 + 1 + 2 = **6**\n" +
+                        "HP: **6**",
+                new String[] { "5", "d4-2" }
+        );
+        expect(
+                "At level 1: 1 = **1**\n" +
+                        "At level 2: 5 + 2 = **7**\n" +
+                        "At level 3: 6 + 6 + 6 = **18**\n" +
+                        "At level 4: 6 + 4 + 4 + 3 = 17, too low, **19** taken\n" +
+                        "At level 5: 6 + 6 + 6 + 5 + 6 = **29**\n" +
+                        "HP: **29**",
+                new String[] { "5", "d6" }
+        );
+    }
+
+    private void expect(String expectedResult, String[] args) {
+        CommandContext context = new CommandContext(new Random(0));
+        String actual = TestUtils.normalize(new RollEmpireOfPetalThroneHPAction().run(args, context));
+        String expected = TestUtils.normalize(expectedResult);
+        Assert.assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Per private request.

Command syntax:
```
  !ept <level> <hit_die_expr>
```
E.g.:
```
  !ept 5 d6+1
```
- roll HP for level 5, with hit die d6+1