### PR TITLE
Support 'tr:' prefix for arbitrary expressions

### DIFF
--- a/src/main/antlr4/org/alessio29/savagebot/r2/grammar/R2.g4
+++ b/src/main/antlr4/org/alessio29/savagebot/r2/grammar/R2.g4
@@ -43,6 +43,8 @@ expression
         # WegD6RollExpr
     |   e1=expression '[' (e2=expression)? ':' (e3=expression)? ']'
         # BoundedExpr
+    |   targetNumberAndRaiseStep ':' e1=expression
+        # TargetNumberAndRaiseStepExpr
     |   v=VAR ':=' e1=expression
         # AssignExpr
     |   e1=expression op=('*'|'/'|'%') e2=expression
@@ -68,17 +70,13 @@ genericRollSuffix
         # SuccessOrFailSuffix1
     |   fop=('f'|'F') fn=term sop=('s'|'S') sn=term
         # SuccessOrFailSuffix2
-    |   ('t'|'T') tn=term (('r'|'R') tr=term)?
-        # TargetNumberAndRaiseStepSuffix1
-    |   ('r'|'R') tr=term (('t'|'T') tn=term)?
-        # TargetNumberAndRaiseStepSuffix2
-    |   ('tr'|'TR') tnr=term
-        # TargetNumberAndRaiseStepSuffix3
+    |   targetNumberAndRaiseStep
+        # TargetNumberAndRaiseStepSuffix
     ;
 
 savageWorldsRoll
     :   (t1=term)? ('s'|'S') t2=term (('w'|'W') t3=term)?
-        targetNumberAndRaiseStep
+        targetNumberAndRaiseStep?
     ;
 
 savageWorldsExtrasRoll
@@ -86,8 +84,9 @@ savageWorldsExtrasRoll
     ;
 
 targetNumberAndRaiseStep
-    :   ('tr'|'TR') ttr=term
-    |   (('t'|'T') tt=term)? (('r'|'R') tr=term)?
+    :   ('tr'|'TR') tnr=term
+    |   ('t'|'T') tt=term (('r'|'R') tr=term)?
+    |   ('r'|'R') tr=term (('t'|'T') tt=term)?
     ;
 
 additiveModifier

--- a/src/main/java/org/alessio29/savagebot/r2/Dumper.java
+++ b/src/main/java/org/alessio29/savagebot/r2/Dumper.java
@@ -199,6 +199,18 @@ public class Dumper implements Statement.Visitor<Void>, Expression.Visitor<Void>
     }
 
     @Override
+    public Void visitTargetNumberAndRaiseStepExpression(TargetNumberAndRaiseStepExpression expression) {
+        println("TargetNumberAndStep");
+        indented(() -> {
+            dump("targetNumber", expression.getTargetNumberArg());
+            dump("raiseStep", expression.getRaiseStepArg());
+            dump("targetNumberAndRaiseStep", expression.getTargetNumberAndRaiseStepArg());
+            dump("argument", expression.getExpression());
+        });
+        return null;
+    }
+
+    @Override
     public Void visitNonParsedStringStatement(NonParsedStringStatement nonParsedStringStatement) {
         println("NonParsedString " +
                 "text='" + nonParsedStringStatement.getText() + "' " +

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionEvaluator.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionEvaluator.java
@@ -329,6 +329,13 @@ public class ExpressionEvaluator implements Expression.Visitor<List<Integer>> {
         return Collections.singletonList(result);
     }
 
+    @Override
+    public List<Integer> visitTargetNumberAndRaiseStepExpression(TargetNumberAndRaiseStepExpression expression) {
+        context.setSavageWorldsMarginOfSuccessRequired(true);
+        handleTargetNumberAndRaiseStep(expression);
+        return eval(expression.getExpression());
+    }
+
     private void handleTargetNumberAndRaiseStep(WithTargetNumberAndRaiseStep expression) {
         Expression targetNumberAndRaiseStepArg = expression.getTargetNumberAndRaiseStepArg();
         if (targetNumberAndRaiseStepArg != null) {

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionExplainer.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionExplainer.java
@@ -335,4 +335,9 @@ class ExpressionExplainer implements Expression.Visitor<String> {
     public String visitWegD6Expression(WegD6RollExpression wegD6RollExpression) {
         return getKnownExplanation(wegD6RollExpression);
     }
+
+    @Override
+    public String visitTargetNumberAndRaiseStepExpression(TargetNumberAndRaiseStepExpression expression) {
+        return getKnownExplanation(expression.getExpression());
+    }
 }

--- a/src/main/java/org/alessio29/savagebot/r2/tree/Expression.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/Expression.java
@@ -31,5 +31,7 @@ public abstract class Expression extends Node {
         V visitWegD6Expression(WegD6RollExpression wegD6RollExpression);
 
         V visitExtrasRollExpression(SavageWorldsExtrasRollExpression savageWorldsExtrasRollExpression);
+
+        V visitTargetNumberAndRaiseStepExpression(TargetNumberAndRaiseStepExpression expression);
     }
 }

--- a/src/main/java/org/alessio29/savagebot/r2/tree/TargetNumberAndRaiseStepExpression.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/TargetNumberAndRaiseStepExpression.java
@@ -1,0 +1,46 @@
+package org.alessio29.savagebot.r2.tree;
+
+public class TargetNumberAndRaiseStepExpression extends Expression implements WithTargetNumberAndRaiseStep {
+    private final Expression targetNumberArg;
+    private final Expression raiseStepArg;
+    private final Expression targetNumberAndRaiseStepArg;
+    private final Expression expression;
+
+    public TargetNumberAndRaiseStepExpression(
+            String text,
+            Expression targetNumberArg,
+            Expression raiseStepArg,
+            Expression targetNumberAndRaiseStepArg,
+            Expression expression
+    ) {
+        super(text);
+        this.targetNumberArg = targetNumberArg;
+        this.raiseStepArg = raiseStepArg;
+        this.targetNumberAndRaiseStepArg = targetNumberAndRaiseStepArg;
+        this.expression = expression;
+    }
+
+    @Override
+    public Expression getTargetNumberArg() {
+        return targetNumberArg;
+    }
+
+    @Override
+    public Expression getRaiseStepArg() {
+        return raiseStepArg;
+    }
+
+    @Override
+    public Expression getTargetNumberAndRaiseStepArg() {
+        return targetNumberAndRaiseStepArg;
+    }
+
+    public Expression getExpression() {
+        return expression;
+    }
+
+    @Override
+    public <V> V accept(Visitor<V> visitor) {
+        return visitor.visitTargetNumberAndRaiseStepExpression(this);
+    }
+}

--- a/src/test/java/org/alessio29/savagebot/parsing/TestR2Interpreter.java
+++ b/src/test/java/org/alessio29/savagebot/parsing/TestR2Interpreter.java
@@ -603,6 +603,40 @@ public class TestR2Interpreter {
     }
 
     @Test
+    public void testTargetNumberAndRaiseExpressionPrefix() {
+        expect(
+                "t6:2d6: 1 + 5 = **6** (shaken, TN: 6)",
+                "t6:2d6"
+        );
+        expect(
+                "t6:2d6+1: 1 + 5 + 1 = **7** (shaken, TN: 6)",
+                "t6:2d6+1"
+        );
+        expect(
+                "t6:2d6+d4+1: 1 + 5 + 1 + 1 = **8** (shaken, TN: 6)",
+                "t6:2d6+d4+1"
+        );
+        expect(
+                "t6:s8+2: [6; w5] + 2 = **8** (2)",
+                "t6:s8+2"
+        );
+        expect(
+                "5xtr6:s6: \n" +
+                        "1: tr6:s6: [1; w5] = **5** (1)\n" +
+                        "2: tr6:s6: [2; w28] = **28** (7)\n" +
+                        "3: tr6:s6: [4; w3] = **4** (1)\n" +
+                        "4: tr6:s6: [23; w9] = **23** (5)\n" +
+                        "5: tr6:s6: [5; w4] = **5** (1)",
+                "5xtr6:s6"
+        );
+        // Only last target number and raise step are taken into account
+        expect(
+                "t6:s6+t8:s8: [1; w5] + [2; w28] = **33** (8)",
+                "t6:s6+t8:s8"
+        );
+    }
+
+    @Test
     public void testMultipleSavageWorldChecksWithTargetNumbers() {
         // Only last TN and raise step is taken into account
         expect(

--- a/src/test/java/org/alessio29/savagebot/parsing/TestR2Parser.java
+++ b/src/test/java/org/alessio29/savagebot/parsing/TestR2Parser.java
@@ -26,7 +26,7 @@ public class TestR2Parser {
                 "NonParsedString text='abc' parserErrorMessage='[0]: token recognition error at: 'ab''\n" +
                         "NonParsedString text='def' parserErrorMessage='[1]: mismatched input 'e' expecting {'%', '(', INT, VAR}'\n" +
                         "NonParsedString text='qwer' parserErrorMessage='[0]: token recognition error at: 'q''\n" +
-                        "NonParsedString text='tty' parserErrorMessage='[0]: mismatched input 't' expecting {'e', 'E', '+', '-', 'd', 'D', 's', 'S', 'dF', 'df', 'DF', 'dC', 'dc', 'DC', '(', INT, FLAG, VAR}'\n" +
+                        "NonParsedString text='tty' parserErrorMessage='[2]: token recognition error at: 'y''\n" +
                         "RollOnce\n" +
                         "  expr: Int 123",
                 "abc def", "  qwer tty", "123"


### PR DESCRIPTION
`!t6:s8+1` looks somewhat more intuitive then `!s8t6+1`.