### PR TITLE
Refactor TN/raise handling

### DIFF
--- a/src/main/java/org/alessio29/savagebot/r2/Dumper.java
+++ b/src/main/java/org/alessio29/savagebot/r2/Dumper.java
@@ -171,9 +171,6 @@ public class Dumper implements Statement.Visitor<Void>, Expression.Visitor<Void>
             }
 
             dump("modifierArg", savageWorldsExtrasRollExpression.getModifierArg());
-            dump("targetNumber", savageWorldsExtrasRollExpression.getTargetNumberArg());
-            dump("raiseStep", savageWorldsExtrasRollExpression.getRaiseStepArg());
-            dump("targetNumberAndRaiseStep", savageWorldsExtrasRollExpression.getTargetNumberAndRaiseStepArg());
         });
         return null;
     }
@@ -185,9 +182,6 @@ public class Dumper implements Statement.Visitor<Void>, Expression.Visitor<Void>
             dump("diceCount", savageWorldsRollExpression.getDiceCountArg());
             dump("abilityDie", savageWorldsRollExpression.getAbilityDieArg());
             dump("wildDie", savageWorldsRollExpression.getWildDieArg());
-            dump("targetNumber", savageWorldsRollExpression.getTargetNumberArg());
-            dump("raiseStep", savageWorldsRollExpression.getRaiseStepArg());
-            dump("targetNumberAndRaiseStep", savageWorldsRollExpression.getTargetNumberAndRaiseStepArg());
         });
         return null;
     }

--- a/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionEvaluator.java
+++ b/src/main/java/org/alessio29/savagebot/r2/eval/ExpressionEvaluator.java
@@ -200,11 +200,6 @@ public class ExpressionEvaluator implements Expression.Visitor<List<Integer>> {
 
         IntResult result;
 
-        if (genericRollExpression.isWithTargetNumberAndRaiseStep()) {
-            context.setSavageWorldsMarginOfSuccessRequired(true);
-            handleTargetNumberAndRaiseStep(genericRollExpression);
-        }
-
         if (genericRollExpression.getSuffixOperator() == GenericRollExpression.SuffixOperator.SUCCESS_OR_FAIL) {
             int successThreshold = evalInt(
                     genericRollExpression.getSuffixArg1(),
@@ -294,8 +289,6 @@ public class ExpressionEvaluator implements Expression.Visitor<List<Integer>> {
         IntListResult result = roller.rollSavageWorlds(diceCount, abilityDieFacets, wildDieFacets);
 
         context.putExplanation(savageWorldsRollExpression, result.getExplained());
-
-        handleTargetNumberAndRaiseStep(savageWorldsRollExpression);
         return result.getValues();
     }
 
@@ -325,33 +318,28 @@ public class ExpressionEvaluator implements Expression.Visitor<List<Integer>> {
         }
 
         context.putExplanation(savageWorldsExtrasRollExpression, explanation.toString());
-        handleTargetNumberAndRaiseStep(savageWorldsExtrasRollExpression);
         return Collections.singletonList(result);
     }
 
     @Override
     public List<Integer> visitTargetNumberAndRaiseStepExpression(TargetNumberAndRaiseStepExpression expression) {
         context.setSavageWorldsMarginOfSuccessRequired(true);
-        handleTargetNumberAndRaiseStep(expression);
-        return eval(expression.getExpression());
-    }
 
-    private void handleTargetNumberAndRaiseStep(WithTargetNumberAndRaiseStep expression) {
-        Expression targetNumberAndRaiseStepArg = expression.getTargetNumberAndRaiseStepArg();
-        if (targetNumberAndRaiseStepArg != null) {
-            int targetNumberAndRaiseStep = evalInt(targetNumberAndRaiseStepArg, 4);
+        if (expression.getTargetNumberAndRaiseStepArg() != null) {
+            int targetNumberAndRaiseStep = evalInt(expression.getTargetNumberAndRaiseStepArg(), 4);
             context.setSavageWorldsTargetNumber(targetNumberAndRaiseStep);
             context.setSavageWorldsRaiseStep(targetNumberAndRaiseStep);
-        } else {
-            if (expression.getTargetNumberArg() != null) {
-                int targetNumber = evalInt(expression.getTargetNumberArg(), 4);
-                context.setSavageWorldsTargetNumber(targetNumber);
-            }
-            if (expression.getRaiseStepArg() != null) {
-                int raiseStep = evalInt(expression.getRaiseStepArg(), 4);
-                context.setSavageWorldsRaiseStep(raiseStep);
-            }
         }
+        if (expression.getTargetNumberArg() != null) {
+            int targetNumber = evalInt(expression.getTargetNumberArg(), 4);
+            context.setSavageWorldsTargetNumber(targetNumber);
+        }
+        if (expression.getRaiseStepArg() != null) {
+            int raiseStep = evalInt(expression.getRaiseStepArg(), 4);
+            context.setSavageWorldsRaiseStep(raiseStep);
+        }
+
+        return eval(expression.getExpression());
     }
 
     @Override

--- a/src/main/java/org/alessio29/savagebot/r2/parse/StatementDesugarer.java
+++ b/src/main/java/org/alessio29/savagebot/r2/parse/StatementDesugarer.java
@@ -60,26 +60,24 @@ class StatementDesugarer extends Desugarer<Statement> {
         Expression n = expressionDesugarer.visit(ctx.n);
         Expression facets = expressionDesugarer.visit(ctx.t1);
 
-        TargetNumberAndRaiseStep tnrs =
-                expressionDesugarer.desugarTargetNumberAndRaiseStep(ctx.targetNumberAndRaiseStep());
-
         R2Parser.AdditiveModifierContext admc = ctx.additiveModifier();
 
         int start = ctx.n != null ? ctx.n.getStop().getStopIndex() + 1 : ctx.getStart().getStartIndex();
         int stop = ctx.getStop().getStopIndex();
         String text = inputString.substring(start, stop + 1);
 
-        Expression rollExpr = new SavageWorldsExtrasRollExpression(
+        Expression expr = expressionDesugarer.desugarTargetNumberAndRaiseStep(
                 text,
-                facets,
-                admc != null ? OperatorExpression.getBinaryOperator(admc.op.getText()) : null,
-                admc != null ? expressionDesugarer.visit(admc.em) : null,
-                tnrs.getTargetNumber(),
-                tnrs.getRaiseStep(),
-                tnrs.getTargetNumberAndRaiseStep()
+                ctx.targetNumberAndRaiseStep(),
+                new SavageWorldsExtrasRollExpression(
+                        text,
+                        facets,
+                        admc != null ? OperatorExpression.getBinaryOperator(admc.op.getText()) : null,
+                        admc != null ? expressionDesugarer.visit(admc.em) : null
+                )
         );
 
-        return new RollTimesStatement(getOriginalText(ctx), n, rollExpr);
+        return new RollTimesStatement(getOriginalText(ctx), n, expr);
     }
 
     private Expression desugarExpression(ParseTree parseTree) {

--- a/src/main/java/org/alessio29/savagebot/r2/tree/GenericRollExpression.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/GenericRollExpression.java
@@ -3,7 +3,7 @@ package org.alessio29.savagebot.r2.tree;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GenericRollExpression extends Expression implements WithTargetNumberAndRaiseStep {
+public class GenericRollExpression extends Expression {
     public enum SuffixOperator {
         KEEP(1, "k", "K"),
         KEEP_LEAST(1, "kl", "KL"),
@@ -62,11 +62,6 @@ public class GenericRollExpression extends Expression implements WithTargetNumbe
     private final Expression suffixArg1;
     private final Expression suffixArg2;
 
-    private final boolean isWithTargetNumberAndRaiseStep;
-    private final Expression targetNumberArg;
-    private final Expression raiseStepArg;
-    private final Expression targetNumberAndRaiseStepArg;
-
     public GenericRollExpression(
             String text,
             Expression diceCountArg,
@@ -83,11 +78,6 @@ public class GenericRollExpression extends Expression implements WithTargetNumbe
         this.suffixOperator = suffixOperator;
         this.suffixArg1 = suffixArg1;
         this.suffixArg2 = suffixArg2;
-
-        this.isWithTargetNumberAndRaiseStep = false;
-        this.targetNumberArg = null;
-        this.raiseStepArg = null;
-        this.targetNumberAndRaiseStepArg = null;
     }
 
     public GenericRollExpression(
@@ -108,31 +98,6 @@ public class GenericRollExpression extends Expression implements WithTargetNumbe
             boolean isOpenEnded
     ) {
         this(text, diceCountArg, facetsCountArg, isOpenEnded, null, null);
-    }
-
-    public GenericRollExpression(
-            String text,
-            Expression diceCountArg,
-            Expression facetsCountArg,
-            boolean isOpenEnded,
-            Expression targetNumberArg,
-            Expression raiseStepArg,
-            Expression targetNumberAndRaiseStepArg
-    ) {
-        super(text);
-
-        this.diceCountArg = diceCountArg;
-        this.facetsCountArg = facetsCountArg;
-        this.isOpenEnded = isOpenEnded;
-
-        this.isWithTargetNumberAndRaiseStep = true;
-        this.targetNumberArg = targetNumberArg;
-        this.raiseStepArg = raiseStepArg;
-        this.targetNumberAndRaiseStepArg = targetNumberAndRaiseStepArg;
-
-        this.suffixOperator = null;
-        this.suffixArg1 = null;
-        this.suffixArg2 = null;
     }
 
     public Expression getDiceCountArg() {
@@ -157,25 +122,6 @@ public class GenericRollExpression extends Expression implements WithTargetNumbe
 
     public Expression getSuffixArg2() {
         return suffixArg2;
-    }
-
-    public boolean isWithTargetNumberAndRaiseStep() {
-        return isWithTargetNumberAndRaiseStep;
-    }
-
-    @Override
-    public Expression getTargetNumberArg() {
-        return targetNumberArg;
-    }
-
-    @Override
-    public Expression getRaiseStepArg() {
-        return raiseStepArg;
-    }
-
-    @Override
-    public Expression getTargetNumberAndRaiseStepArg() {
-        return targetNumberAndRaiseStepArg;
     }
 
     @Override

--- a/src/main/java/org/alessio29/savagebot/r2/tree/SavageWorldsExtrasRollExpression.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/SavageWorldsExtrasRollExpression.java
@@ -1,29 +1,20 @@
 package org.alessio29.savagebot.r2.tree;
 
-public class SavageWorldsExtrasRollExpression extends Expression implements WithTargetNumberAndRaiseStep {
+public class SavageWorldsExtrasRollExpression extends Expression {
     private final Expression facetsArg;
     private final OperatorExpression.Operator modifierOperator;
     private final Expression modifierArg;
-    private final Expression targetNumberArg;
-    private final Expression raiseStepArg;
-    private final Expression targetNumberAndRaiseStepArg;
 
     public SavageWorldsExtrasRollExpression(
             String text,
             Expression facetsArg,
             OperatorExpression.Operator modifierOperator,
-            Expression modifierArg,
-            Expression targetNumberArg,
-            Expression raiseStepArg,
-            Expression targetNumberAndRaiseStepArg
+            Expression modifierArg
     ) {
         super(text);
         this.facetsArg = facetsArg;
         this.modifierOperator = modifierOperator;
         this.modifierArg = modifierArg;
-        this.targetNumberArg = targetNumberArg;
-        this.raiseStepArg = raiseStepArg;
-        this.targetNumberAndRaiseStepArg = targetNumberAndRaiseStepArg;
     }
 
     public Expression getFacetsArg() {
@@ -36,21 +27,6 @@ public class SavageWorldsExtrasRollExpression extends Expression implements With
 
     public Expression getModifierArg() {
         return modifierArg;
-    }
-
-    @Override
-    public Expression getTargetNumberArg() {
-        return targetNumberArg;
-    }
-
-    @Override
-    public Expression getRaiseStepArg() {
-        return raiseStepArg;
-    }
-
-    @Override
-    public Expression getTargetNumberAndRaiseStepArg() {
-        return targetNumberAndRaiseStepArg;
     }
 
     @Override

--- a/src/main/java/org/alessio29/savagebot/r2/tree/SavageWorldsRollExpression.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/SavageWorldsRollExpression.java
@@ -1,29 +1,20 @@
 package org.alessio29.savagebot.r2.tree;
 
-public class SavageWorldsRollExpression extends Expression implements WithTargetNumberAndRaiseStep {
+public class SavageWorldsRollExpression extends Expression {
     private final Expression diceCountArg;
     private final Expression abilityDieArg;
     private final Expression wildDieArg;
-    private final Expression targetNumberArg;
-    private final Expression raiseStepArg;
-    private final Expression targetNumberAndRaiseStepArg;
 
     public SavageWorldsRollExpression(
             String text,
             Expression diceCountArg,
             Expression abilityDieArg,
-            Expression wildDieArg,
-            Expression targetNumberArg,
-            Expression raiseStepArg,
-            Expression targetNumberAndRaiseStepArg
+            Expression wildDieArg
     ) {
         super(text);
         this.diceCountArg = diceCountArg;
         this.abilityDieArg = abilityDieArg;
         this.wildDieArg = wildDieArg;
-        this.targetNumberArg = targetNumberArg;
-        this.raiseStepArg = raiseStepArg;
-        this.targetNumberAndRaiseStepArg = targetNumberAndRaiseStepArg;
     }
 
     public Expression getDiceCountArg() {
@@ -36,21 +27,6 @@ public class SavageWorldsRollExpression extends Expression implements WithTarget
 
     public Expression getWildDieArg() {
         return wildDieArg;
-    }
-
-    @Override
-    public Expression getTargetNumberArg() {
-        return targetNumberArg;
-    }
-
-    @Override
-    public Expression getRaiseStepArg() {
-        return raiseStepArg;
-    }
-
-    @Override
-    public Expression getTargetNumberAndRaiseStepArg() {
-        return targetNumberAndRaiseStepArg;
     }
 
     @Override

--- a/src/main/java/org/alessio29/savagebot/r2/tree/TargetNumberAndRaiseStepExpression.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/TargetNumberAndRaiseStepExpression.java
@@ -1,6 +1,6 @@
 package org.alessio29.savagebot.r2.tree;
 
-public class TargetNumberAndRaiseStepExpression extends Expression implements WithTargetNumberAndRaiseStep {
+public class TargetNumberAndRaiseStepExpression extends Expression {
     private final Expression targetNumberArg;
     private final Expression raiseStepArg;
     private final Expression targetNumberAndRaiseStepArg;
@@ -20,17 +20,14 @@ public class TargetNumberAndRaiseStepExpression extends Expression implements Wi
         this.expression = expression;
     }
 
-    @Override
     public Expression getTargetNumberArg() {
         return targetNumberArg;
     }
 
-    @Override
     public Expression getRaiseStepArg() {
         return raiseStepArg;
     }
 
-    @Override
     public Expression getTargetNumberAndRaiseStepArg() {
         return targetNumberAndRaiseStepArg;
     }

--- a/src/main/java/org/alessio29/savagebot/r2/tree/WithTargetNumberAndRaiseStep.java
+++ b/src/main/java/org/alessio29/savagebot/r2/tree/WithTargetNumberAndRaiseStep.java
@@ -1,7 +1,0 @@
-package org.alessio29.savagebot.r2.tree;
-
-public interface WithTargetNumberAndRaiseStep {
-    Expression getTargetNumberArg();
-    Expression getRaiseStepArg();
-    Expression getTargetNumberAndRaiseStepArg();
-}

--- a/src/test/java/org/alessio29/savagebot/parsing/TestR2Parser.java
+++ b/src/test/java/org/alessio29/savagebot/parsing/TestR2Parser.java
@@ -190,10 +190,7 @@ public class TestR2Parser {
                         "  expr: SavageWorldsRoll\n" +
                         "    diceCount: null\n" +
                         "    abilityDie: Int 8\n" +
-                        "    wildDie: null\n" +
-                        "    targetNumber: null\n" +
-                        "    raiseStep: null\n" +
-                        "    targetNumberAndRaiseStep: null",
+                        "    wildDie: null",
                 "s8"
         );
         expect(
@@ -203,9 +200,6 @@ public class TestR2Parser {
                         "      diceCount: null\n" +
                         "      abilityDie: Int 8\n" +
                         "      wildDie: null\n" +
-                        "      targetNumber: null\n" +
-                        "      raiseStep: null\n" +
-                        "      targetNumberAndRaiseStep: null\n" +
                         "    arg2: Int 2",
                 "s8+2"
         );
@@ -214,10 +208,7 @@ public class TestR2Parser {
                         "  expr: SavageWorldsRoll\n" +
                         "    diceCount: Int 2\n" +
                         "    abilityDie: Int 8\n" +
-                        "    wildDie: null\n" +
-                        "    targetNumber: null\n" +
-                        "    raiseStep: null\n" +
-                        "    targetNumberAndRaiseStep: null",
+                        "    wildDie: null",
                 "2s8"
         );
         expect(
@@ -225,11 +216,20 @@ public class TestR2Parser {
                         "  expr: SavageWorldsRoll\n" +
                         "    diceCount: Int 2\n" +
                         "    abilityDie: Int 8\n" +
-                        "    wildDie: Int 10\n" +
-                        "    targetNumber: null\n" +
-                        "    raiseStep: null\n" +
-                        "    targetNumberAndRaiseStep: null",
+                        "    wildDie: Int 10",
                 "2s8w10"
+        );
+        expect(
+                "RollOnce\n" +
+                        "  expr: TargetNumberAndStep\n" +
+                        "    targetNumber: Int 7\n" +
+                        "    raiseStep: null\n" +
+                        "    targetNumberAndRaiseStep: null\n" +
+                        "    argument: SavageWorldsRoll\n" +
+                        "      diceCount: null\n" +
+                        "      abilityDie: Int 8\n" +
+                        "      wildDie: null",
+                "s8t7"
         );
     }
 
@@ -261,9 +261,6 @@ public class TestR2Parser {
                         "        diceCount: null\n" +
                         "        abilityDie: Int 8\n" +
                         "        wildDie: null\n" +
-                        "        targetNumber: null\n" +
-                        "        raiseStep: null\n" +
-                        "        targetNumberAndRaiseStep: null\n" +
                         "      arg2: FudgeRoll\n" +
                         "        diceCount: Int 2\n" +
                         "    arg2: Int 2",


### PR DESCRIPTION
All TN/taise handling now happens in TargetNumberAndRaiseStepExpression evaluation.
Savage Worlds and generic rolls with t/r/tr suffixes are desugared as wrapped with t/r/tr prefix.
E.g., 's8t6' is desugared as 't6:s8'.